### PR TITLE
utils/entrypoint.sh must exit with a error on missing command

### DIFF
--- a/utils/entrypoint.sh
+++ b/utils/entrypoint.sh
@@ -23,3 +23,5 @@ echo "	logger"
 echo "	snapshot-downloader"
 echo "	wait-for-bootstrap"
 echo "	faucet-gen"
+
+exit 1


### PR DESCRIPTION
Fixes #258 