### PR TITLE
update to v10, fix default network

### DIFF
--- a/charts/tezos/scripts/config-init.sh
+++ b/charts/tezos/scripts/config-init.sh
@@ -10,3 +10,5 @@ mkdir -p /etc/tezos/data
     --network $CHAIN_NAME
 
 cat /etc/tezos/data/config.json
+
+printf "\n\n\n\n\n\n\n"

--- a/charts/tezos/values.yaml
+++ b/charts/tezos/values.yaml
@@ -8,7 +8,7 @@ is_invitation: false
 
 # Images not part of the tezos-k8s repo go here
 images:
-  tezos: tezos/tezos:v9-release
+  tezos: tezos/tezos:v10-release
   tezedge: tezedge/tezedge:v1.6.8
 # Images that are part of the tezos-k8s repo go here with 'dev' tag
 tezos_k8s_images:

--- a/utils/config-generator.py
+++ b/utils/config-generator.py
@@ -547,7 +547,12 @@ def create_node_config_json(
         #  Either way, set the `network` field here as the `network` object of the
         #  produced config.json.
         with open("/etc/tezos/data/config.json", "r") as f:
-            node_config["network"] = json.load(f)["network"]
+            node_config_orig = json.load(f)
+            if "network" in node_config_orig:
+                node_config["network"] = node_config_orig["network"]
+            else:
+                node_config["network"] = "mainnet"
+            
     else:
         if CHAIN_PARAMS.get("expected-proof-of-work") != None:
             node_config["p2p"]["expected-proof-of-work"] = CHAIN_PARAMS[


### PR DESCRIPTION
Updates tezos to v10-release

Fixes issue when no creds are given.

Newlines appended to config-init.sh to prevent log from cutting off in k9s.

Fixes #273 #272 