### PR TITLE
Open acls always

### DIFF
--- a/charts/tezos/templates/configs.yaml
+++ b/charts/tezos/templates/configs.yaml
@@ -17,7 +17,6 @@ data:
 {{ .Values.nodes | mustToPrettyJson | indent 4 }}
   SIGNERS: |
 {{ .Values.signers | mustToPrettyJson | indent 4 }}
-  OPEN_ACLS: "{{ .Values.open_acls }}"
 kind: ConfigMap
 metadata:
   name: tezos-config

--- a/charts/tezos/values.yaml
+++ b/charts/tezos/values.yaml
@@ -15,14 +15,6 @@ tezos_k8s_images:
   utils: tezos-k8s-utils:dev
   zerotier: tezos-k8s-zerotier:dev
 
-# octez v11 or superior requires explicitly opening up ACLs for other
-# containers to be able to do sentitive RPC operations to it
-# for example chain activation
-#
-# But v10 or less does not recognize the argument.
-# Set this toggle to true when using octez v11.
-open_acls: false
-
 # Properties that are templated in Helm template files
 tzkt_indexer_statefulset:
   name: tzkt-indexer

--- a/utils/config-generator.py
+++ b/utils/config-generator.py
@@ -17,7 +17,6 @@ ACCOUNTS = json.loads(os.environ["ACCOUNTS"])
 CHAIN_PARAMS = json.loads(os.environ["CHAIN_PARAMS"])
 NODES = json.loads(os.environ["NODES"])
 SIGNERS = json.loads(os.environ["SIGNERS"])
-OPEN_ACLS = os.environ["OPEN_ACLS"]
 
 MY_POD_NAME = os.environ["MY_POD_NAME"]
 MY_POD_TYPE = os.environ["MY_POD_TYPE"]
@@ -529,6 +528,7 @@ def create_node_config_json(
         "data-dir": "/var/tezos/node/data",
         "rpc": {
             "listen-addrs": [f"{os.getenv('MY_POD_IP')}:8732", "127.0.0.1:8732"],
+            "acl": [ { "address": os.getenv('MY_POD_IP'), "blacklist": [] } ]
         },
         "p2p": {
             "bootstrap-peers": bootstrap_peers,
@@ -536,8 +536,6 @@ def create_node_config_json(
         },
         # "log": {"level": "debug"},
     }
-    if OPEN_ACLS == "true":
-        computed_node_config["rpc"]["acl"] = [ { "address": os.getenv('MY_POD_IP'), "blacklist": [] } ]
     node_config = recursive_update(values_node_config, computed_node_config)
 
     if THIS_IS_A_PUBLIC_NET:


### PR DESCRIPTION
on v10, acls are enabled by default.
Before, we had an `open_acls` toggle so we could still support v9. Now that we only want to support v10 onwards, I removed the toggle and whitelist all ACLs instead.