### PR TITLE
Add option to start node with local storage

### DIFF
--- a/charts/tezos/templates/nodes.yaml
+++ b/charts/tezos/templates/nodes.yaml
@@ -44,6 +44,11 @@ spec:
           name: dev-net-tun
         - emptyDir: {}
           name: config-volume
+{{- $local_storage := $val.local_storage | default false }}
+{{- if $local_storage }}
+        - emptyDir: {}
+          name: var-volume
+{{- else }}
   volumeClaimTemplates:
     - metadata:
         name: var-volume
@@ -54,6 +59,7 @@ spec:
         resources:
           requests:
             storage: {{ default "15Gi" $val.storage_size }}
+{{- end }}
 ---
 {{- end }}
 {{- end }}

--- a/charts/tezos/templates/nodes.yaml
+++ b/charts/tezos/templates/nodes.yaml
@@ -44,8 +44,7 @@ spec:
           name: dev-net-tun
         - emptyDir: {}
           name: config-volume
-{{- $local_storage := $val.local_storage | default false }}
-{{- if $local_storage }}
+{{- if $val.local_storage | default false }}
         - emptyDir: {}
           name: var-volume
 {{- else }}

--- a/charts/tezos/values.yaml
+++ b/charts/tezos/values.yaml
@@ -89,6 +89,8 @@ accounts: {}
 ##             config.json. Run `tezos-node config --help` for more info.
 ##   - "node_selector": Specify a kubernetes node selector in 'key: value' format
 ##     for your tezos nodes.
+##   - "local_storage": use a local node storage that gets reset each time the pod
+##     restarts; effectively syncs from a snpashot each time. Defaults to false
 ##
 ##
 ## defaults are filled in for most values.
@@ -103,6 +105,7 @@ accounts: {}
 #     images: # (optional field)
 #       octez: tezos/tezos:v...
 #     # tezedge: tezedge/tezedg:v...
+#     local_storage: false
 #     runs:
 #       - octez_node
 #     # - tezedge_node

--- a/charts/tezos/values.yaml
+++ b/charts/tezos/values.yaml
@@ -81,6 +81,9 @@ accounts: {}
 ## - "runs": A list of containers to run. A tezos node implementation is required.
 ##         Options being "octez_node" or "tezedge_node". Other optional
 ##         containers are "baker", "endorser", "logger", and "metrics".
+## - "local_storage": use local storage instead of a volume. The storage will be
+##                  wiped when the node restarts for any reason. Useful when
+##                  faster IO is desired. Defaults to false.
 ## - "instances": a list of nodes to fire up, each is a dictionary defining:
 ##   - "bake_using_account": Account name that should be used for baking.
 ##   - "bake_using_accounts": List of account names that should be used for baking.
@@ -89,8 +92,6 @@ accounts: {}
 ##             config.json. Run `tezos-node config --help` for more info.
 ##   - "node_selector": Specify a kubernetes node selector in 'key: value' format
 ##     for your tezos nodes.
-##   - "local_storage": use a local node storage that gets reset each time the pod
-##     restarts; effectively syncs from a snpashot each time. Defaults to false
 ##
 ##
 ## defaults are filled in for most values.


### PR DESCRIPTION
Useful for faster IO for baking and RPC use cases.

Must sync from snapshot or tarball.