### PR TITLE
Readiness probe for tezos-node

### DIFF
--- a/charts/tezos/scripts/tezos-sidecar.py
+++ b/charts/tezos/scripts/tezos-sidecar.py
@@ -1,0 +1,44 @@
+from flask import Flask, escape, request
+import requests
+import datetime
+
+import logging
+log = logging.getLogger('werkzeug')
+log.setLevel(logging.ERROR)
+
+application = Flask(__name__)
+
+AGE_LIMIT_IN_SECS = 600
+
+@application.route('/is_synced')
+def sync_checker():
+    '''
+    Here we don't trust the /is_bootstrapped endpoint of
+    tezos-node. We have seen it return true when the node is
+    in a bad state (for example, some crashed threads)
+    Instead, we query the head block and verify timestamp is
+    not too old.
+    '''
+    try:
+        r = requests.get('http://127.0.0.1:8732/chains/main/blocks/head/header')
+    except requests.exceptions.RequestException as e:
+        err = "Could not connect to node, %s" % repr(e), 500
+        print(err)
+        return err
+    header = r.json()
+    if header["level"] == 0:
+        # when chain has not been activated, bypass age check
+        # and return succesfully to mark as ready
+        # otherwise it will never activate (activation uses rpc service)
+        return "Chain has not been activated yet"
+    timestamp = r.json()["timestamp"]
+    block_age = datetime.datetime.utcnow() -  datetime.datetime.strptime(timestamp, '%Y-%m-%dT%H:%M:%SZ')
+    age_in_secs = block_age.total_seconds()
+    if age_in_secs > AGE_LIMIT_IN_SECS:
+        err = "Error: Chain head is %s secs old, older than %s" % ( age_in_secs, AGE_LIMIT_IN_SECS), 500
+        print(err)
+        return err
+    return "Chain is bootstrapped"
+
+if __name__ == "__main__":
+   application.run(host = "0.0.0.0", port = 31732, debug = False)

--- a/charts/tezos/templates/_containers.tpl
+++ b/charts/tezos/templates/_containers.tpl
@@ -154,6 +154,10 @@
       name: config-volume
     - mountPath: /var/tezos
       name: var-volume
+  readinessProbe:
+    httpGet:
+      path: /is_synced
+      port: 31732
 {{- end }}
 {{- end }}
 
@@ -327,6 +331,18 @@ https://github.com/helm/helm/issues/5979#issuecomment-518231758
   env:
 {{- include "tezos.localvars.pod_envvars" . | indent 4 }}
 {{- end }}
+{{- end }}
+
+{{- define "tezos.container.sidecar" }}
+- command:
+    - python
+  args:
+    - "-c"
+    - |
+{{ tpl (.Files.Get "scripts/tezos-sidecar.py") . | indent 6 }}
+  image: {{ .Values.tezos_k8s_images.utils }}
+  imagePullPolicy: IfNotPresent
+  name: sidecar
 {{- end }}
 
 {{- define "tezos.container.zerotier" }}

--- a/charts/tezos/templates/nodes.yaml
+++ b/charts/tezos/templates/nodes.yaml
@@ -28,6 +28,7 @@ spec:
 {{- include "tezos.container.logger"    $ | indent 8 }}
 {{- include "tezos.container.metrics"   $ | indent 8 }}
 {{- include "tezos.container.zerotier"  $ | indent 8 }}
+{{- include "tezos.container.sidecar"   $ | indent 8 }}
       initContainers:
 {{- include "tezos.init_container.config_init"         $ | indent 8 }}
 {{- include "tezos.init_container.wait_for_bootstrap"  $ | indent 8 }}

--- a/utils/Dockerfile
+++ b/utils/Dockerfile
@@ -14,7 +14,7 @@ RUN     apk add --no-cache --virtual .build-deps gcc g++ python3-dev	\
      && apk add zeromq-dev						\
      && pip install base58 pynacl					\
      && pip install pytezos requests                                    \
-     && pip install pyblake2 pysodium numpy \
+     && pip install pyblake2 pysodium numpy flask \
      && pip install -e 'git+https://github.com/vbuterin/pybitcointools.git@aeb0a2bbb8bbfe421432d776c649650eaeb882a5#egg=bitcoin' \
      && apk del .build-deps git \
      && apk add jq netcat-openbsd curl binutils


### PR DESCRIPTION
We already had a readiness probe for tzkt, this PR adds it for the node
itself.

This is done by a python sidecar. When it receives a get request on the
/is_synced endpoint, it will query the node head block header and verify
timestamp is less than 10 minutes old.

We are using a http probe served by a flask/werkzeug server. I had to
add flask to the utils container.

When the chain is not bootstrapped, it is considered healthy so the
activation call can reach it.

This is important for a RPC server with several endpoints as they may
not all be synced. For example, when you just created the statefulset,
they sync in sequential order.

More importantly, in combination with #282 health check becomes more
important. As the chain syncs from snapshot or tarball each time it is
launched, it is important to not direct RPC traffic to nodes that are
still syncing.