### PR TITLE
switch genesis proto to mainnet-genesis

### DIFF
--- a/charts/tezos/values.yaml
+++ b/charts/tezos/values.yaml
@@ -158,7 +158,7 @@ expected_proof_of_work: 26
 #   genesis:
 #     timestamp: "2021-03-04T20:00:00Z"
 #     block: YOUR_GENESIS_BLOCK_HASH_HERE
-#     protocol: PtYuensgYBb3G3x1hLLbCmcav8ue8Kyd2khADcL5LsT5R1hcXex
+#     protocol: Ps9mPmXaRzmzk35gbAYNCAw6UXdE2qoABTHbN2oEEc1qM7CwT9P
 #   # The name of the account who's public key will be set downstream in
 #   # config.json at `network.genesis_parameters.values.genesis_pubkey`.
 #   activation_account_name: baker0

--- a/mkchain/tqchain/mkchain.py
+++ b/mkchain/tqchain/mkchain.py
@@ -199,7 +199,7 @@ def main():
             "block": get_genesis_vanity_chain_id()
             if not args.should_generate_unsafe_deterministic_data
             else "YOUR_GENESIS_BLOCK_HASH_HERE",
-            "protocol": "PtYuensgYBb3G3x1hLLbCmcav8ue8Kyd2khADcL5LsT5R1hcXex",
+            "protocol": "Ps9mPmXaRzmzk35gbAYNCAw6UXdE2qoABTHbN2oEEc1qM7CwT9P",
             "timestamp": datetime.utcnow().replace(tzinfo=timezone.utc).isoformat(),
         }
 


### PR DESCRIPTION
It looks like since the beginning of tezos-k8s we had been using the
`PtYUEN` protocol which is carthage-bootstrap.

Nomadic is going to remove this protocol from tezos source so they asked
that we switch to tezos mainnet activation. Doing this here for our
mkchain-generated values.yaml files and the commented out example in the
default one.