### PR TITLE
remove commitments file mechanism

### DIFF
--- a/charts/tezos/values.yaml
+++ b/charts/tezos/values.yaml
@@ -225,12 +225,8 @@ protocols:
 #   # This data is typically too large to pass it directly inside helm chart.
 #   bootstrap_contract_urls: []
 #
-#   # Pass url pointing to a json file listing commitments (precursor to faucet accounts).
-#   # This data is typically too large to pass it directly inside helm chart.
-#   commitments_url: "https://bucket/commitments.json"
-#
-#   # Instead of pre-existing commitments file, use the "deteministic_faucet" map
-#   # to predictably create a desired number of faucet accounts.
+#   # Use the "deteministic_faucet" map to predictably create a desired
+#   # number of faucet accounts.
 #   # The seed can be shared with an instance of the tezos-faucet project
 #   #   https://gitlab.com/nomadic-labs/tezos-faucet
 #   # so you can deploy a website where people get free tez from the faucet.


### PR DESCRIPTION
Since hangzhounet, we are no longer using the old file from
faucet.tzalpha.net, instead we are generating deterministic faucet
accounts from a seed. We no longer need this mechanism to download this
large commitment file from s3, so I am removing it as a feature from
tezos-k8s.