### PR TITLE
Configurable Tzkt storage

### DIFF
--- a/charts/tezos/templates/tzkt_indexer.yaml
+++ b/charts/tezos/templates/tzkt_indexer.yaml
@@ -318,6 +318,6 @@ spec:
         storageClassName: {{ .Values.tzkt_indexer_statefulset.storageClassName }}
         resources:
           requests:
-            storage: "50Gi"
+            storage: {{ required "DB storage size must be specified" .Values.tzkt_indexer_statefulset.storage  }}
 
 {{- end }}

--- a/charts/tezos/values.yaml
+++ b/charts/tezos/values.yaml
@@ -19,6 +19,8 @@ tezos_k8s_images:
 tzkt_indexer_statefulset:
   name: tzkt-indexer
   storageClassName: ""
+  # Mainnet indexer requires a lot of storage
+  storage: "100Gi"
 signer_statefulset:
   name: tezos-signer
   pod_type: signing

--- a/charts/tezos/values.yaml
+++ b/charts/tezos/values.yaml
@@ -150,11 +150,12 @@ signers: {}
 full_snapshot_url: https://mainnet.xtz-shots.io/full
 rolling_snapshot_url: https://mainnet.xtz-shots.io/rolling
 
-# Alternatively to a snapshot, you can download a public LZ4-compressed filesystem tar
-# of a node's /var/tezos/node folder by putting the URL to the archive file in tarball_url:
-# NOTE: tarballl_url and *_snapshot_url are mutually exclusive. When tarball_url is 
-# configured,full_snapshot_url and rolling_snapshot_url must be null.
-# tarball_url: 
+## Alternatively to a Tezos snapshot, you can download a public LZ4-compressed
+## filesystem tar of a node's data directory by setting the tarball_url field to
+## the URL of the archive file. NOTE: tarball_url and *_snapshot_url are
+## mutually exclusive. When tarball_url is configured, full_snapshot_url and
+## rolling_snapshot_url must be null.
+# tarball_url:
 
 # List of peers for nodes to connect to. Gets set under config.json `p2p` field
 bootstrap_peers: []


### PR DESCRIPTION
Turns out mainnet tzkt indexer needs a lot of storage. This pr makes the storage field configurable. 