### PR TITLE
Tzkt statefulset annotations + don't re-download snapshot on pod restart

### DIFF
--- a/charts/tezos/templates/tzkt_indexer.yaml
+++ b/charts/tezos/templates/tzkt_indexer.yaml
@@ -59,6 +59,12 @@ data:
 
     echo "Snapshot imported"
     echo "$SNAPSHOT_URL" > "$MY_IMPORTED_SNAPSHOTS_URL"
+{{/*
+TIP: When developing, you can choose to persist the snapshot file after it's
+imported. This will save time as the pod would not have to re-download it. To
+enable this, add `keep_snapshot_after_import: true` in the tzkt section of
+values.yaml. File name format is "{db_name}-{indexer_image_tag}.backup".
+*/}}
   {{ if not $tzkt_indexer.keep_snapshot_after_import }}
     rm -fv "$SNAPSHOT_FILE"
   {{ end }}

--- a/charts/tezos/values.yaml
+++ b/charts/tezos/values.yaml
@@ -276,11 +276,6 @@ protocols:
 #     ## https://github.com/baking-bad/tzkt
 #     db_snapshot_url: https://tzkt-snapshots.s3.eu-central-1.amazonaws.com/tzkt_v1.6_mainnet.backup
 #
-#     ## For developing: you can choose to persist the snapshot file after it's
-#     ## imported so that the pod would never have to re-download it. The files
-#     ## name format is "{db_name}-{indexer_image_tag}.backup"
-#     # keep_snapshot_after_import: true
-#
 #     ## Configurable tzkt fields
 #     config:
 #       ## url of the archive node to index


### PR DESCRIPTION
PR stops re-downloading a snapshot on pod restart when `keep_snapshot_after_import: false`