### PR TITLE
deprecate endorser binary

### DIFF
--- a/charts/tezos/templates/_containers.tpl
+++ b/charts/tezos/templates/_containers.tpl
@@ -234,24 +234,16 @@ https://github.com/helm/helm/issues/5979#issuecomment-518231758
 {{- include "tezos.localvars.pod_envvars" $ | indent 4 }}
     - name: DAEMON
       value: baker
-{{- end }}
-{{- end }}
-{{- end }}
-
-{{- define "tezos.container.endorsers" }}
-{{- if has "endorser" $.node_vals.runs }}
-{{ $node_vals_images := $.node_vals.images | default dict }}
-{{- range .Values.protocols }}
+{{- if or (regexFind "GRANAD" .command) (regexFind "Hangz" .command) }}
+{{- /*
+Also start endorser for protocols that need it.
+*/}}
 - image: "{{ or $node_vals_images.octez $.Values.images.octez }}"
   command:
     - /bin/sh
   args:
     - "-c"
     - |
-{{- /*
-Below set is a trick to get the range and global context. See:
-https://github.com/helm/helm/issues/5979#issuecomment-518231758
-*/}}
 {{- $_ := set $ "command_in_tpl" .command }}
 {{ tpl ($.Files.Get "scripts/baker-endorser.sh") $ | indent 6 }}
   imagePullPolicy: IfNotPresent
@@ -273,6 +265,8 @@ https://github.com/helm/helm/issues/5979#issuecomment-518231758
 {{- end }}
 {{- end }}
 {{- end }}
+{{- end }}
+
 
 {{- define "tezos.container.logger" }}
 {{- if has "logger" $.node_vals.runs }}

--- a/charts/tezos/templates/nodes.yaml
+++ b/charts/tezos/templates/nodes.yaml
@@ -30,7 +30,6 @@ spec:
         {{- include "tezos.container.node"      $ | indent 8 }}
         {{- include "tezos.container.tezedge"   $ | indent 8 }}
         {{- include "tezos.container.bakers"    $ | indent 8 }}
-        {{- include "tezos.container.endorsers" $ | indent 8 }}
         {{- include "tezos.container.logger"    $ | indent 8 }}
         {{- include "tezos.container.metrics"   $ | indent 8 }}
         {{- include "tezos.container.zerotier"  $ | indent 8 }}

--- a/charts/tezos/values.yaml
+++ b/charts/tezos/values.yaml
@@ -73,13 +73,13 @@ accounts: {}
 ## Params at the statefulset level:
 ## - "storage_size": the size of the PV
 ## - "images": Optional specification of images to use for the tezos node and
-##           baker/endorser. Options are "octez" with a tezos/tezos image or
+##           baker. Options are "octez" with a tezos/tezos image or
 ##           "tezedge" with a tezedge/tezedge image. If no images are provided,
 ##           the containers will default to the images defined in the "images"
 ##           field up above.
 ## - "runs": A list of containers to run. A tezos node implementation is required.
 ##         Options being "octez_node" or "tezedge_node". Other optional
-##         containers are "baker", "endorser", "logger", and "metrics".
+##         containers are "baker", "logger", and "metrics".
 ## - "local_storage": use local storage instead of a volume. The storage will be
 ##                  wiped when the node restarts for any reason. Useful when
 ##                  faster IO is desired. Defaults to false.
@@ -117,7 +117,6 @@ accounts: {}
 #       - octez_node
 #     # - tezedge_node
 #       - baker
-#       - endorser
 #     instances:
 #       - bake_using_account: baker0
 #         is_bootstrap_node: true
@@ -207,8 +206,8 @@ node_config_network:
   chain_name: mainnet
 
 protocols:
-  # Tezos builds baker and endorser binaries for every supported protocol.
-  # List here the protocols that you wish to run bakers and endorsers for.
+  # Tezos builds baker binaries for every supported protocol.
+  # List here the protocols that you wish to run bakers for.
   # These binaries must be present in the docker image specified.
   # You may want to run two or more if you are expecting an on-chain upgrade.
   # Be mindful that running more protocols will start more containers in your

--- a/mkchain/tqchain/mkchain.py
+++ b/mkchain/tqchain/mkchain.py
@@ -229,7 +229,7 @@ def main():
     # archive mode. Any other bakers will be in rolling mode.
     creation_nodes = {
         BAKER_NODE_NAME: {
-            "runs": ["octez_node", "baker", "endorser"],
+            "runs": ["octez_node", "baker"],
             "storage_size": "15Gi",
             "instances": [
                 node_config(BAKER_NODE_NAME, n, is_baker=True)


### PR DESCRIPTION
Mondaynet starts on Hangzhou then upgrades to alpha. Hangzhou has an
endorser but alpha does not. Currently there is no way to handle this.
This PR fixes it.

The endorser days are numbered, so instead of giving people to start or
not start an endorser based on the protocol, I just hardcoded this
simple logic:

  Start endorser if granada or hangzhou, else not.