### PR TITLE
The wait-for-dns init container should be last.

### DIFF
--- a/charts/tezos/templates/nodes.yaml
+++ b/charts/tezos/templates/nodes.yaml
@@ -38,9 +38,9 @@ spec:
         {{- include "tezos.init_container.config_init"         $ | indent 8 }}
         {{- include "tezos.init_container.zerotier"            $ | indent 8 }}
         {{- include "tezos.init_container.config_generator"    $ | indent 8 }}
-        {{- include "tezos.init_container.wait_for_dns"        $ | indent 8 }}
         {{- include "tezos.init_container.snapshot_downloader" $ | indent 8 }}
         {{- include "tezos.init_container.snapshot_importer"   $ | indent 8 }}
+        {{- include "tezos.init_container.wait_for_dns"        $ | indent 8 }}
       securityContext:
         fsGroup: 100
 {{- include "tezos.nodeSelectorConfig" $ | indent 6 }}


### PR DESCRIPTION
This allows us to download/import snapshots and/or tarballs on all the
nodes at the same time.