### PR TITLE
Provide a mechanism to run only one tezos-node pod per k8s node.

### DIFF
--- a/charts/tezos/templates/nodes.yaml
+++ b/charts/tezos/templates/nodes.yaml
@@ -26,6 +26,18 @@ spec:
         {{- $.node_vals.labels | toYaml | nindent 8 }}
         {{- end }}
     spec:
+{{- if $.Values.node_globals.one_node_per_vm }}
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: appType
+                operator: In
+                values:
+                - tezos-node
+            topologyKey: "kubernetes.io/hostname"
+{{- end }}
       containers:
         {{- include "tezos.container.node"      $ | indent 8 }}
         {{- include "tezos.container.tezedge"   $ | indent 8 }}

--- a/charts/tezos/values.yaml
+++ b/charts/tezos/values.yaml
@@ -60,6 +60,12 @@ accounts: {}
 #     is_bootstrap_baker_account: false
 #     bootstrap_balance: "4000000000000"
 
+## node_globals.env defines environment variables which will be
+## set in every container on every node:
+
+node_globals:
+  one_node_per_vm: false
+
 ## NODES
 ##
 ## "nodes" is a dictionary where each key/value pair defines a statefulset and a

--- a/pulumi/index.ts
+++ b/pulumi/index.ts
@@ -63,6 +63,13 @@ if (desiredClusterCapacity > maxClusterCapacity) {
 			 ' "pulumi config set max-cluster-capacity N"');
 }
 
+if (nodesPerVM == 1) {
+    if (helmValues["node_global"] == undefined) {
+	helmValues["node_global"] = {};
+    }
+    helmValues["node_global"]["one_node_per_vm"] = true;
+}
+
 function createWorkerNodeRole(name: string): aws.iam.Role {
     const managedPolicyArns: string[] = [
         "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy",


### PR DESCRIPTION
We also turn this functionality on by default in pulumi if we are configured to have 1 node per vm.