### PR TITLE
history_mode can take an object as well as a string

### DIFF
--- a/utils/snapshot-downloader.sh
+++ b/utils/snapshot-downloader.sh
@@ -10,7 +10,11 @@ snapshot_file=$node_dir/chain.snapshot
 my_nodes_history_mode=$(echo $NODES | jq -r "
 				.\"${MY_NODE_CLASS}\"
 				.instances[${MY_POD_NAME#$MY_NODE_CLASS-}]
-				.config.shell.history_mode")
+				.config.shell.history_mode
+				|if type == \"object\" then
+					(keys|.[0])
+				 else .
+				 end")
 
 echo My nodes history mode: $my_nodes_history_mode
 


### PR DESCRIPTION
As it turns out, history mode can take an object as well as a string and
in this case, the object has a single key corresponding to the history
mode and its value are additional settings, e.g. additional_cycles.

Fixes #324.