### PR TITLE
Upgrade helm to 3.5.3 for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,7 +203,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v1
         with:
-          version: v3.4.2
+          version: v3.5.3
 
       - name: Lint Helm Charts
         run: helm lint charts/*


### PR DESCRIPTION
I'm getting the following helm failure

```
Error:  templates/snapshotWarmer.yaml: object name must be between 0 and 253 characters: ""
```

https://github.com/oxheadalpha/tezos-k8s/runs/4887781135?check_suite_focus=true

with my chart

https://github.com/oxheadalpha/tezos-k8s/blob/publish-to-xtz-shots/charts/snapshot-warmer/templates/snapshotWarmer.yaml

This has been downgraded to a warning as helm is not detecting the resource type correctly and is thinking it is a DNS name or something else.

https://github.com/helm/helm/issues/9019#issuecomment-763826760

We could also omit the version and let the helm CI action default to latest stable.

https://github.com/Azure/setup-helm#example

Reproduce locally

```
git pull origin publish-to-xtz-shots
```
```
helm lint ithacanet-shots/tezos-k8s/charts/snapshot-warmer
```

If your helm version is higher it should be a warning

```
[WARNING] templates/snapshotWarmer.yaml: object name must be between 0 and 253 characters: ""
```