### PR TITLE
add ability to pass node identity as values (fix #311)

### DIFF
--- a/charts/tezos/templates/_containers.tpl
+++ b/charts/tezos/templates/_containers.tpl
@@ -45,6 +45,10 @@
     - "config-generator"
     - "--generate-config-json"
   envFrom:
+    {{- if len .node_identities }}
+    - secretRef:
+        name: {{ .node_class }}-indentities-secret
+    {{- end }}
     - secretRef:
         name: tezos-secret
     - configMapRef:

--- a/charts/tezos/templates/configs.yaml
+++ b/charts/tezos/templates/configs.yaml
@@ -17,8 +17,20 @@ data:
   ROLLING_TARBALL_URL: "{{ .Values.rolling_tarball_url }}"
   NODE_GLOBALS: |
 {{ .Values.node_globals | mustToPrettyJson | indent 4 }}
+
   NODES: |
-{{ .Values.nodes | mustToPrettyJson | indent 4 }}
+{{/*
+  Remove "identity" field from nodes. Creates a deep copy because
+  "unset" modifies the object.
+*/}}
+{{- $nodes_copy := deepCopy .Values.nodes }}
+{{- range $node_class, $node_config := $nodes_copy }}
+  {{- range $_, $instance_config := $node_config.instances }}
+    {{- $_ := unset $instance_config "identity" }}
+  {{- end }}
+{{- end }}
+{{ $nodes_copy | mustToPrettyJson | indent 4 }}
+
   SIGNERS: |
 {{ .Values.signers | mustToPrettyJson | indent 4 }}
 kind: ConfigMap

--- a/charts/tezos/templates/nodes.yaml
+++ b/charts/tezos/templates/nodes.yaml
@@ -2,6 +2,10 @@
 {{- if $val }}
   {{- $_ := set $ "node_class" $key }}
   {{- $_ := set $ "node_vals" $val }}
+  {{- $_ := set $ "node_identities" dict }}
+
+  {{- include "tezos.includeNodeIdentitySecret" $ }}
+
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/charts/tezos/values.yaml
+++ b/charts/tezos/values.yaml
@@ -88,18 +88,23 @@ accounts: {}
 ## - "local_storage": use local storage instead of a volume. The storage will be
 ##                  wiped when the node restarts for any reason. Useful when
 ##                  faster IO is desired. Defaults to false.
-## - "instances": a list of nodes to fire up, each is a dictionary defining:
-##   - "bake_using_account": Account name that should be used for baking.
-##   - "bake_using_accounts": List of account names that should be used for baking.
-##   - "is_bootstrap_node": Is this node a bootstrap peer.
-##   - "config": same as the outer level, pass through to config.json.  At
-##               the instance level, it overrides the statefulset level.
+## - "labels": https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+##      NOTE: the labels appType, node_class, and baking_node are set
+##      automatically for you.
 ## - "node_selector": Specify a kubernetes node selector in 'key: value' format
 ##     for your tezos nodes.
-## - "labels": https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
-##   NOTE: the labels appType, node_class, and baking_node are set
-##         automatically for you.
-##
+## - "instances": a list of nodes to fire up, each is a dictionary defining:
+##    - "bake_using_account": Account name that should be used for baking.
+##    - "bake_using_accounts": List of account names that should be used for baking.
+##    - "config": Same as the outer statefulset level "config". It overrides the
+##                statefulset level.
+##    - "is_bootstrap_node": Is this node a bootstrap peer.
+##    - "identity": An optional map containing a pre-generated Tezos node
+##                 identity. This is useful for local storage nodes which would
+##                 need to generate an identity at every boot. The identity file
+##                 will be created at /var/tezos/node/data/identity.json.
+##                 Required fields are "peer_id", "public_key", "secret_key",
+##                 and "proof_of_work_timestamp".
 ##
 ## Defaults are filled in for most of the above values.  You can also provide
 ## global defaults for all nodes via a node_globals: section which is also
@@ -141,13 +146,10 @@ accounts: {}
 #         config:
 #           shell:
 #             history_mode: rolling
-#         # optional - pass a node identity so it is not generated at first boot
-#         # This is useful for local storage nodes which must do that at every boot
-#         # The structure must match the node's identity.json file
 #         identity:
 #            peer_id: id...
 #            public_key: ...
-#            private_key: ...
+#            secret_key: ...
 #            proof_of_work_stamp: ...
 #   rolling-node:
 #     labels:

--- a/charts/tezos/values.yaml
+++ b/charts/tezos/values.yaml
@@ -141,6 +141,14 @@ accounts: {}
 #         config:
 #           shell:
 #             history_mode: rolling
+#         # optional - pass a node identity so it is not generated at first boot
+#         # This is useful for local storage nodes which must do that at every boot
+#         # The structure must match the node's identity.json file
+#         identity:
+#            peer_id: id...
+#            public_key: ...
+#            private_key: ...
+#            proof_of_work_stamp: ...
 #   rolling-node:
 #     labels:
 #       # Example labels you might use to specify certain attributes of your nodes.

--- a/utils/config-generator.py
+++ b/utils/config-generator.py
@@ -15,6 +15,7 @@ from base58 import b58encode_check
 
 ACCOUNTS = json.loads(os.environ["ACCOUNTS"])
 CHAIN_PARAMS = json.loads(os.environ["CHAIN_PARAMS"])
+DATA_DIR = "/var/tezos/node/data"
 NODE_GLOBALS = json.loads(os.environ["NODE_GLOBALS"]) or {}
 NODES = json.loads(os.environ["NODES"])
 SIGNERS = json.loads(os.environ["SIGNERS"])
@@ -140,6 +141,13 @@ def main():
         with open("/etc/tezos/config.json", "w") as json_file:
             print(config_json, file=json_file)
 
+        if MY_POD_CONFIG.get("identity", False):
+            print("\nWriting identity.json file from config")
+            os.makedirs(DATA_DIR,exist_ok=True)
+            os.chmod(DATA_DIR, 0o777)
+            with open(f"{DATA_DIR}/identity.json", "w") as json_file:
+                print(json.dumps(MY_POD_CONFIG.get("identity")), file=json_file)
+            os.chmod(f"{DATA_DIR}/identity.json", 0o777)
 
 # If NETWORK_CONFIG["genesis"]["block"] hasn't been specified, we generate a
 # deterministic one.
@@ -529,7 +537,7 @@ def create_node_config_json(
     """Create the node's config.json file"""
 
     computed_node_config = {
-        "data-dir": "/var/tezos/node/data",
+        "data-dir": DATA_DIR,
         "rpc": {
             "listen-addrs": [f"{os.getenv('MY_POD_IP')}:8732", "127.0.0.1:8732"],
             "acl": [ { "address": os.getenv('MY_POD_IP'), "blacklist": [] } ]

--- a/utils/config-generator.py
+++ b/utils/config-generator.py
@@ -4,11 +4,12 @@ import json
 import os
 import requests
 import socket
+from grp import getgrnam
 from hashlib import blake2b
-from json.decoder import JSONDecodeError
-from operator import itemgetter
 from pathlib import Path
 from re import sub
+from shutil import chown
+
 
 from pytezos import pytezos
 from base58 import b58encode_check
@@ -18,6 +19,7 @@ CHAIN_PARAMS = json.loads(os.environ["CHAIN_PARAMS"])
 DATA_DIR = "/var/tezos/node/data"
 NODE_GLOBALS = json.loads(os.environ["NODE_GLOBALS"]) or {}
 NODES = json.loads(os.environ["NODES"])
+NODE_IDENTITIES = json.loads(os.getenv("NODE_IDENTITIES", "{}"))
 SIGNERS = json.loads(os.environ["SIGNERS"])
 
 MY_POD_NAME = os.environ["MY_POD_NAME"]
@@ -67,6 +69,10 @@ def main():
     if MY_POD_NAME in BAKING_NODES:
         # If this node is a baker, it must have an account with a secret key.
         verify_this_bakers_account(all_accounts)
+
+    # Create the node's identity.json if its values are provided
+    if NODE_IDENTITIES.get(MY_POD_NAME, False):
+        create_node_identity_json()
 
     main_parser = argparse.ArgumentParser()
     main_parser.add_argument(
@@ -141,13 +147,6 @@ def main():
         with open("/etc/tezos/config.json", "w") as json_file:
             print(config_json, file=json_file)
 
-        if MY_POD_CONFIG.get("identity", False):
-            print("\nWriting identity.json file from config")
-            os.makedirs(DATA_DIR,exist_ok=True)
-            os.chmod(DATA_DIR, 0o777)
-            with open(f"{DATA_DIR}/identity.json", "w") as json_file:
-                print(json.dumps(MY_POD_CONFIG.get("identity")), file=json_file)
-            os.chmod(f"{DATA_DIR}/identity.json", 0o777)
 
 # If NETWORK_CONFIG["genesis"]["block"] hasn't been specified, we generate a
 # deterministic one.
@@ -423,6 +422,29 @@ def import_keys(all_accounts):
     json.dump(public_key_hashs, open(tezdir + "/public_key_hashs", "w"), indent=4)
 
 
+def create_node_identity_json():
+    identity_file_path = f"{DATA_DIR}/identity.json"
+    path = Path(identity_file_path)
+    if path.exists() and path.stat().st_size > 0:
+        return
+
+    # Manually create the data directory and identity.json, and give the
+    # same dir/file permissions that tezos gives when it creates them.
+    print("\nWriting identity.json file from the instance config")
+
+    os.makedirs(DATA_DIR, 0o700, exist_ok=True)
+    with open(
+        identity_file_path,
+        "w",
+        opener=lambda path, flags: os.open(path, flags, 0o644),
+    ) as identity_file:
+        print(json.dumps(NODE_IDENTITIES.get(MY_POD_NAME)), file=identity_file)
+
+    nogroup = getgrnam("nogroup").gr_gid
+    chown(DATA_DIR, user=100, group=nogroup)
+    chown(identity_file_path, user=100, group=nogroup)
+
+
 #
 # get_genesis_accounts_pubkey_and_balance(accounts) returns a list
 # of lists: [ [key1, balance2], [key2, balance2], ... ] for all of
@@ -431,8 +453,6 @@ def import_keys(all_accounts):
 # start.  If just a public key hash is provided, then it is not.  We
 # use a public key if the property "is_bootstrap_baker_account" is
 # either absent or true.
-
-
 def get_genesis_accounts_pubkey_and_balance(accounts):
     pubkey_and_balance_pairs = []
 

--- a/utils/config-generator.sh
+++ b/utils/config-generator.sh
@@ -46,6 +46,7 @@ EOM
 # variables and we are not guaranteed to have jq available on an arbitrary
 # tezos docker image.
 
+set +x
 MY_CLASS=$(echo $NODES | jq -r ".\"${MY_NODE_CLASS}\"")
 AM_I_BAKER=0
 if [ "$MY_CLASS" != null ]; then

--- a/utils/config-generator.sh
+++ b/utils/config-generator.sh
@@ -46,7 +46,6 @@ EOM
 # variables and we are not guaranteed to have jq available on an arbitrary
 # tezos docker image.
 
-set +x
 MY_CLASS=$(echo $NODES | jq -r ".\"${MY_NODE_CLASS}\"")
 AM_I_BAKER=0
 if [ "$MY_CLASS" != null ]; then


### PR DESCRIPTION
with the advent of tarballs, spinning up tezos nodes with local storage
is very fast. But each time it starts, it generates a new identity, which
requires solving a proof-of-work puzzle which takes few seconds to 1-2
minutes.

You can now generate these identities out-of-band, and record them in
values.yaml at node level, and save this time at boot of your local
storage-backed node.

This is not supported at node_class or global level since each identity
must be unique.

~A controversial choice I made is to add these inside the tezos-config
configMap instead of a secret. Thinking about it, these identity keys
are not that secret, even though they use public key cryptography and
have a "secret" key. The impact of a leak is that you can spoof a peer
and potentially knock it off the network. It is not bad enough that we
would want to create a k8s secret. Due to helm limitations, we would have to
make a new top-level object in values.yaml especially for secrets, which
must match the structure of `nodes`. This would not be great for
usability.~

The identity contains a secret key, so it is stored in a kubernetes secret and pruned from the configmap containing all of the node's info.

~That being said, I add a `set +x` around the bottom of
config-generator.sh so we don't unnecessarily print this key in the
logs.~