### PR TITLE
make tezos-client command work without passing client dir as param

### DIFF
--- a/charts/tezos/scripts/baker-endorser.sh
+++ b/charts/tezos/scripts/baker-endorser.sh
@@ -17,6 +17,9 @@ my_baker_account="$(cat /etc/tezos/baker-account )"
 CLIENT="$TEZ_BIN/tezos-client -d $CLIENT_DIR"
 CMD="$TEZ_BIN/tezos-$DAEMON-$proto_command -d $CLIENT_DIR"
 
+# ensure we can run tezos-client commands without specifying client dir
+ln -s /var/tezos/client /home/tezos/.tezos-client
+
 while ! $CLIENT rpc get chains/main/blocks/head; do
     sleep 5
 done

--- a/charts/tezos/scripts/tezos-node.sh
+++ b/charts/tezos/scripts/tezos-node.sh
@@ -2,6 +2,8 @@ set -x
 
 set
 
+# ensure we can run tezos-client commands without specifying client dir
+ln -s /var/tezos/client /home/tezos/.tezos-client
 #
 # Not every error is fatal on start.  In particular, with zerotier,
 # the listen-addr may not yet be bound causing tezos-node to fail.


### PR DESCRIPTION
This is very neat because I can open a shell into the node or baker and
type `tezos-client list known addresses` and it just works.

Q: why a symink instead of moving the actual dir to
/home/tezos/.tezos-client ?

A: the potential for breakage is high if we move the dir. This makes the
startup script a bit longer but there is virtually no risk of breakage.