### PR TITLE
make readiness probe optional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,7 +203,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v1
         with:
-          version: v3.5.3
+          version: v3.8.1
 
       - name: Lint Helm Charts
         run: helm lint charts/*

--- a/charts/tezos/templates/_containers.tpl
+++ b/charts/tezos/templates/_containers.tpl
@@ -356,6 +356,7 @@ Also start endorser for protocols that need it.
 {{- end }}
 
 {{- define "tezos.container.sidecar" }}
+{{- if not (eq $.node_vals.readiness_probe false) }}
 - command:
     - python
   args:
@@ -365,6 +366,7 @@ Also start endorser for protocols that need it.
   image: {{ .Values.tezos_k8s_images.utils }}
   imagePullPolicy: IfNotPresent
   name: sidecar
+{{- end }}
 {{- end }}
 
 {{- define "tezos.container.zerotier" }}

--- a/charts/tezos/templates/_containers.tpl
+++ b/charts/tezos/templates/_containers.tpl
@@ -160,10 +160,12 @@
       name: config-volume
     - mountPath: /var/tezos
       name: var-volume
+{{- if not (eq  $.node_vals.readiness_probe false) }}
   readinessProbe:
     httpGet:
       path: /is_synced
       port: 31732
+{{- end }}
 {{- end }}
 {{- end }}
 

--- a/charts/tezos/templates/nodes.yaml
+++ b/charts/tezos/templates/nodes.yaml
@@ -38,7 +38,9 @@ spec:
         {{- include "tezos.container.logger"    $ | indent 8 }}
         {{- include "tezos.container.metrics"   $ | indent 8 }}
         {{- include "tezos.container.zerotier"  $ | indent 8 }}
+        {{- if not (eq  $.node_vals.readiness_probe false) }}
         {{- include "tezos.container.sidecar"   $ | indent 8 }}
+        {{- end }}
       initContainers:
         {{- include "tezos.init_container.config_init"         $ | indent 8 }}
         {{- include "tezos.init_container.zerotier"            $ | indent 8 }}

--- a/charts/tezos/templates/nodes.yaml
+++ b/charts/tezos/templates/nodes.yaml
@@ -38,7 +38,7 @@ spec:
         {{- include "tezos.container.logger"    $ | indent 8 }}
         {{- include "tezos.container.metrics"   $ | indent 8 }}
         {{- include "tezos.container.zerotier"  $ | indent 8 }}
-        {{- if not (eq  $.node_vals.readiness_probe false) }}
+        {{- if not (eq $.node_vals.readiness_probe false) }}
         {{- include "tezos.container.sidecar"   $ | indent 8 }}
         {{- end }}
       initContainers:

--- a/charts/tezos/templates/nodes.yaml
+++ b/charts/tezos/templates/nodes.yaml
@@ -38,9 +38,7 @@ spec:
         {{- include "tezos.container.logger"    $ | indent 8 }}
         {{- include "tezos.container.metrics"   $ | indent 8 }}
         {{- include "tezos.container.zerotier"  $ | indent 8 }}
-        {{- if not (eq $.node_vals.readiness_probe false) }}
         {{- include "tezos.container.sidecar"   $ | indent 8 }}
-        {{- end }}
       initContainers:
         {{- include "tezos.init_container.config_init"         $ | indent 8 }}
         {{- include "tezos.init_container.zerotier"            $ | indent 8 }}

--- a/charts/tezos/values.yaml
+++ b/charts/tezos/values.yaml
@@ -93,6 +93,15 @@ accounts: {}
 ##      automatically for you.
 ## - "node_selector": Specify a kubernetes node selector in 'key: value' format
 ##     for your tezos nodes.
+## - "readiness_probe": Attach a probe to the node. The probe checks whether
+##                    the most recent block is recent enough. If not, the
+##                    services will be unreachable. Defaults to True.
+##                    True is good for RPC nodes, private nodes, and
+##                    self-contained private chains.
+##                    Recommended to set to False when bootstrapping a new
+##                    chain with external bakers, such as a new test chain.
+##                    Otherwise, the chain may become unreachable externally
+##                    while waiting for other nodes to come online.
 ## - "instances": a list of nodes to fire up, each is a dictionary defining:
 ##    - "bake_using_account": Account name that should be used for baking.
 ##    - "bake_using_accounts": List of account names that should be used for baking.


### PR DESCRIPTION
For Teztnets, it's useful to disable this probe: when I start a new
testnet, sometimes I am waiting for other participants to join for the
chain to kick off.

When recreating dailynet or mondaynet, I need to wait for other peers to
connect to me to download the most recent blocks: with a probe, that's
not possible.

Must be explicitly set to false, otherwise by default the probe will be
present. It can only be set at node type level. Since it's processed by
helm and not config-generator, I didn't see a way to make it
configurable at global or instance level.

I will need this to migrate teztnets to the new aws org without disruption.