### PR TITLE
update flextesa in mkchain

### DIFF
--- a/mkchain/tqchain/keys.py
+++ b/mkchain/tqchain/keys.py
@@ -83,7 +83,7 @@ def get_genesis_vanity_chain_id(seed_len=16):
 
     return (
         run_docker(
-            "registry.gitlab.com/tezos/flextesa:01e3f596-run",
+            "registry.gitlab.com/tezos/flextesa:03668c43-run",
             "flextesa",
             "vani",
             '""',


### PR DESCRIPTION
The flextesa container used in mkchain no longer exists in the registry
(as I found out when changing laptop). Changing to a version that is
still there. I tested it and it works.