### PR TITLE
Fix Helm error when a node class is set to null

### DIFF
--- a/charts/tezos/templates/configs.yaml
+++ b/charts/tezos/templates/configs.yaml
@@ -20,8 +20,9 @@ data:
 
   NODES: |
 {{/*
-  Remove "identity" field from nodes. Creates a deep copy because
-  "unset" modifies the object.
+  Don't add node classes without configuration to the configmap.
+  Also remove the secret "identity" field on node instances. Creates
+  a deep copy because "unset" modifies the object.
 */}}
 {{- $nodes_copy := deepCopy .Values.nodes }}
 {{- range $node_class, $node_config := $nodes_copy }}
@@ -29,9 +30,11 @@ data:
     {{- range $_, $instance_config := $node_config.instances }}
       {{- $_ := unset $instance_config "identity" }}
     {{- end }}
+  {{- else }}
+    {{- $_ := unset $nodes_copy $node_class }}
   {{- end }}
 {{- end }}
-{{ $nodes_copy | mustToPrettyJson | indent 4 }}
+{{- $nodes_copy | mustToPrettyJson | indent 4 }}
 
   SIGNERS: |
 {{ .Values.signers | mustToPrettyJson | indent 4 }}

--- a/charts/tezos/templates/configs.yaml
+++ b/charts/tezos/templates/configs.yaml
@@ -25,8 +25,10 @@ data:
 */}}
 {{- $nodes_copy := deepCopy .Values.nodes }}
 {{- range $node_class, $node_config := $nodes_copy }}
-  {{- range $_, $instance_config := $node_config.instances }}
-    {{- $_ := unset $instance_config "identity" }}
+  {{- if $node_config }}
+    {{- range $_, $instance_config := $node_config.instances }}
+      {{- $_ := unset $instance_config "identity" }}
+    {{- end }}
   {{- end }}
 {{- end }}
 {{ $nodes_copy | mustToPrettyJson | indent 4 }}


### PR DESCRIPTION
If this was defined:
```yaml
nodes:
  tezos-node: null
```
the code removing node identities in the tezos-config configmap would fail. It assumes that a populated object is always set for a node class.