### PR TITLE
fix issue with the readiness probe toggle and older helm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,7 +203,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v1
         with:
-          version: v3.5.3
+          version: v3.8.1
 
       - name: Lint Helm Charts
         run: helm lint charts/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,7 +203,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v1
         with:
-          version: v3.8.1
+          version: v3.5.3
 
       - name: Lint Helm Charts
         run: helm lint charts/*

--- a/charts/tezos/templates/_containers.tpl
+++ b/charts/tezos/templates/_containers.tpl
@@ -160,7 +160,7 @@
       name: config-volume
     - mountPath: /var/tezos
       name: var-volume
-{{- if not (eq  $.node_vals.readiness_probe false) }}
+{{- if or (not (hasKey $.node_vals "readiness_probe")) (not (eq $.node_vals.readiness_probe false)) }}
   readinessProbe:
     httpGet:
       path: /is_synced
@@ -356,7 +356,7 @@ Also start endorser for protocols that need it.
 {{- end }}
 
 {{- define "tezos.container.sidecar" }}
-{{- if not (eq $.node_vals.readiness_probe false) }}
+{{- if or (not (hasKey $.node_vals "readiness_probe")) (not (eq $.node_vals.readiness_probe false)) }}
 - command:
     - python
   args:

--- a/charts/tezos/templates/_containers.tpl
+++ b/charts/tezos/templates/_containers.tpl
@@ -160,7 +160,7 @@
       name: config-volume
     - mountPath: /var/tezos
       name: var-volume
-{{- if or (not (hasKey $.node_vals "readiness_probe")) (not (eq $.node_vals.readiness_probe false)) }}
+{{- if or (not (hasKey $.node_vals "readiness_probe")) $.node_vals.readiness_probe }}
   readinessProbe:
     httpGet:
       path: /is_synced
@@ -356,7 +356,7 @@ Also start endorser for protocols that need it.
 {{- end }}
 
 {{- define "tezos.container.sidecar" }}
-{{- if not (and (hasKey $.node_vals "readiness_probe") (eq $.node_vals.readiness_probe false)) }}
+{{- if or (not (hasKey $.node_vals "readiness_probe")) $.node_vals.readiness_probe }}
 - command:
     - python
   args:

--- a/charts/tezos/templates/_containers.tpl
+++ b/charts/tezos/templates/_containers.tpl
@@ -356,7 +356,7 @@ Also start endorser for protocols that need it.
 {{- end }}
 
 {{- define "tezos.container.sidecar" }}
-{{- if or (not (hasKey $.node_vals "readiness_probe")) (not (eq $.node_vals.readiness_probe false)) }}
+{{- if not (and (hasKey $.node_vals "readiness_probe") (eq $.node_vals.readiness_probe false)) }}
 - command:
     - python
   args:


### PR DESCRIPTION
A previous PR #397  introduced a problem with helm linting. Upgrading helm version fixes it, but I am fixing the underlying issue. `readiness_probe` may be unset in the node config or set to false or true. It causes type comparison errors:

```
Error: template: tezos-chain/templates/nodes.yaml:34:12: executing "tezos-chain/templates/nodes.yaml" at <include "tezos.container.node" $>: error calling include: template: tezos-chain/templates/_containers.tpl:163:12: executing "tezos.container.node" at <eq $.node_vals.readiness_probe false>: error calling eq: incompatible types for comparison
```

This better way of doing the check eliminates the type error on older helm.

I suspect the issue was not limited to linting, I've seen it pop up in pulumi runs. Also it may impact users with old helm versions.

I verified by reverting the helm version used for linting to an older one in this PR, then revert it back.