### PR TITLE
make hard-coded identity work when snapshot is being imported

### DIFF
--- a/utils/config-generator.py
+++ b/utils/config-generator.py
@@ -425,12 +425,11 @@ def import_keys(all_accounts):
 def create_node_identity_json():
     identity_file_path = f"{DATA_DIR}/identity.json"
     path = Path(identity_file_path)
-    if path.exists() and path.stat().st_size > 0:
-        return
 
     # Manually create the data directory and identity.json, and give the
     # same dir/file permissions that tezos gives when it creates them.
     print("\nWriting identity.json file from the instance config")
+    print(f"Node id: {NODE_IDENTITIES.get(MY_POD_NAME)['peer_id']}")
 
     os.makedirs(DATA_DIR, 0o700, exist_ok=True)
     with open(
@@ -443,6 +442,7 @@ def create_node_identity_json():
     nogroup = getgrnam("nogroup").gr_gid
     chown(DATA_DIR, user=100, group=nogroup)
     chown(identity_file_path, user=100, group=nogroup)
+    print(f"Identity file written at {identity_file_path}")
 
 
 #

--- a/utils/snapshot-downloader.sh
+++ b/utils/snapshot-downloader.sh
@@ -51,7 +51,8 @@ if [ -n "$snapshot_url" ] && [ -n "$tarball_url" ]; then
   echo "ERROR: Either only a snapshot or tarball url may be specified per Tezos node history mode."
 fi
 
-rm -rfv "$node_data_dir"
+# We are inporting a tarball or snapshot, first we remove everything execpt identity.json
+find $node_data_dir ! -name 'identity.json' -type f -exec rm -vf {} +
 mkdir -p "$node_data_dir"
 
 if [ -n "$snapshot_url" ]; then


### PR DESCRIPTION
Snapshot import wipes the data dir. But we may write an identity.json
file in it. This PR ensures that we are not deleting it after writing
it!

We also write it at every boot (because what if the user wants to change
it?)

We add the node id in the debug log for config-generator.