### PR TITLE
Snapshot downloader: support full history mode tarballs

### DIFF
--- a/charts/tezos/templates/_helpers.tpl
+++ b/charts/tezos/templates/_helpers.tpl
@@ -68,8 +68,12 @@
   Returns a string "true" or empty string which is falsey.
 */}}
 {{- define "tezos.shouldDownloadSnapshot" -}}
-  {{- if or (.Values.full_snapshot_url) (.Values.rolling_snapshot_url) (.Values.rolling_tarball_url) (.Values.archive_tarball_url) }}
-    {{- if and (.Values.rolling_tarball_url) (.Values.rolling_snapshot_url) }}
+  {{- if or (.Values.full_snapshot_url) (.Values.full_tarball_url)
+            (.Values.rolling_snapshot_url) (.Values.rolling_tarball_url)
+            (.Values.archive_tarball_url) }}
+    {{- if or (and (.Values.rolling_tarball_url) (.Values.rolling_snapshot_url))
+        (and (.Values.full_tarball_url) (.Values.full_snapshot_url))
+    }}
       {{- fail "Either only a snapshot url or tarball url may be specified per Tezos node history mode" }}
     {{- else }}
       {{- "true" }}

--- a/charts/tezos/templates/configs.yaml
+++ b/charts/tezos/templates/configs.yaml
@@ -12,9 +12,10 @@ data:
       "protocol_activation": {{ .Values.activation | mustToPrettyJson | indent 8 | trim }}
     }
   FULL_SNAPSHOT_URL: "{{ .Values.full_snapshot_url }}"
+  FULL_TARBALL_URL: "{{ .Values.full_tarball_url }}"
   ROLLING_SNAPSHOT_URL: "{{ .Values.rolling_snapshot_url }}"
-  ARCHIVE_TARBALL_URL: "{{ .Values.archive_tarball_url }}"
   ROLLING_TARBALL_URL: "{{ .Values.rolling_tarball_url }}"
+  ARCHIVE_TARBALL_URL: "{{ .Values.archive_tarball_url }}"
   NODE_GLOBALS: |
 {{ .Values.node_globals | mustToPrettyJson | indent 4 }}
 

--- a/utils/snapshot-downloader.sh
+++ b/utils/snapshot-downloader.sh
@@ -31,7 +31,8 @@ echo "My nodes history mode: '$my_nodes_history_mode'"
 snapshot_url=""
 tarball_url=""
 case "$my_nodes_history_mode" in
-  full)     snapshot_url="$FULL_SNAPSHOT_URL";;
+  full)     snapshot_url="$FULL_SNAPSHOT_URL"
+            tarball_url="$FULL_TARBALL_URL";;
 
   rolling)  snapshot_url="$ROLLING_SNAPSHOT_URL"
             tarball_url="$ROLLING_TARBALL_URL";;


### PR DESCRIPTION
Currently some history mode allows tarball import, other allow snapshot imports.
Furthermore it seems that tarball where not extracted at the right place. 

This MR 
- makes it more uniform by allowing tarball and snapshot imports for all history modes.
-  fix the data-dir where snapshot is downloaded
- remove peers.json file to prevent undesired connections to external network in case the tarball contains such file 