### PR TITLE
Separate deterministic generation of accounts and genesis definition

### DIFF
--- a/charts/tezos/templates/configs.yaml
+++ b/charts/tezos/templates/configs.yaml
@@ -6,7 +6,9 @@ data:
       "bootstrap_peers": {{ toJson .Values.bootstrap_peers }},
       "default_bootstrap_mutez": "{{ .Values.bootstrap_mutez }}",
       "expected-proof-of-work": {{ toJson .Values.expected_proof_of_work }},
-
+      "should_generate_unsafe_deterministic_data": {{ toJson .Values.should_generate_unsafe_deterministic_data }},
+      "should_generate_unsafe_deterministic_genesis_data": {{ toJson .Values.should_generate_unsafe_deterministic_genesis_data }},
+      "should_generate_unsafe_deterministic_account_data": {{ toJson .Values.should_generate_unsafe_deterministic_account_data }},
       "should_generate_unsafe_deterministic_data": {{ toJson .Values.should_generate_unsafe_deterministic_data }},
       "network": {{ mustToPrettyJson .Values.node_config_network | indent 8 | trim }},
       "protocol_activation": {{ .Values.activation | mustToPrettyJson | indent 8 | trim }}

--- a/utils/config-generator.py
+++ b/utils/config-generator.py
@@ -51,6 +51,19 @@ SHOULD_GENERATE_UNSAFE_DETERMINISTIC_DATA = CHAIN_PARAMS.get(
     "should_generate_unsafe_deterministic_data"
 )
 
+SHOULD_GENERATE_UNSAFE_DETERMINISTIC_GENESIS_DATA = CHAIN_PARAMS.get(
+    "should_generate_unsafe_deterministic_genesis_data"
+)
+SHOULD_GENERATE_UNSAFE_DETERMINISTIC_ACCOUNT_DATA = CHAIN_PARAMS.get(
+    "should_generate_unsafe_deterministic_account_data"
+)
+
+if SHOULD_GENERATE_UNSAFE_DETERMINISTIC_GENESIS_DATA == None :
+    SHOULD_GENERATE_UNSAFE_DETERMINISTIC_GENESIS_DATA = SHOULD_GENERATE_UNSAFE_DETERMINISTIC_DATA
+if SHOULD_GENERATE_UNSAFE_DETERMINISTIC_ACCOUNT_DATA == None :
+    SHOULD_GENERATE_UNSAFE_DETERMINISTIC_ACCOUNT_DATA = SHOULD_GENERATE_UNSAFE_DETERMINISTIC_DATA
+
+
 # If there are no genesis params, this is a public chain.
 THIS_IS_A_PUBLIC_NET = True if not NETWORK_CONFIG.get("genesis") else False
 
@@ -58,8 +71,10 @@ THIS_IS_A_PUBLIC_NET = True if not NETWORK_CONFIG.get("genesis") else False
 def main():
     all_accounts = ACCOUNTS
 
-    if SHOULD_GENERATE_UNSAFE_DETERMINISTIC_DATA:
+    if SHOULD_GENERATE_UNSAFE_DETERMINISTIC_GENESIS_DATA:
         fill_in_missing_genesis_block()
+
+    if SHOULD_GENERATE_UNSAFE_DETERMINISTIC_ACCOUNT_DATA:
         all_accounts = fill_in_missing_accounts()
         fill_in_missing_keys(all_accounts)
 
@@ -293,7 +308,12 @@ def fill_in_missing_keys(all_accounts):
                 f"  Deriving secret key for account "
                 + f"{account_name} from genesis_block"
             )
-            seed = account_name + ":" + NETWORK_CONFIG["genesis"]["block"]
+            try:
+                network_seed=NETWORK_CONFIG["genesis"]["block"]
+            except:
+                network_seed="no genesis block"
+
+            seed = account_name + ":" + network_seed
             sk = blake2b(seed.encode(), digest_size=32).digest()
             sk_b58 = b58encode_check(edsk + sk).decode("utf-8")
             account_values["key"] = sk_b58


### PR DESCRIPTION
For resilience testnet, the structure of  the yaml file makes it necessary to activate the generation of deterministic data to declare bakers name and their dispatching amongst pod. 
We then  rewrite the wallet with a yes-wallet, who's keys are twisted for yes-crypto, that allows to bake "in the name of mainnet bakers" with patched nodes.
However we don't want to generate data for genesis as we are using a mainnet context.

This MR allows to split the `SHOULD_GENERATE_UNSAFE_DETERMINISTIC_DATA` into tow option that control which of accounts or genesis have to be generated.
