### PR TITLE
remove hardcoded volume class name, fix #417

### DIFF
--- a/snapshotEngine/createVolumeSnapshot.yaml
+++ b/snapshotEngine/createVolumeSnapshot.yaml
@@ -6,6 +6,5 @@ metadata:
   labels:
     history_mode: rolling
 spec:
-  volumeSnapshotClassName: test-snapclass
   source:
     persistentVolumeClaimName: ""


### PR DESCRIPTION
from kube doc

A volume snapshot can request a particular class by specifying the name
of a VolumeSnapshotClass using the attribute volumeSnapshotClassName. If
nothing is set, then the default class is used if available.

https://kubernetes.io/docs/concepts/storage/volume-snapshots/