### PR TITLE
Ability to adjust or disable the snapshot storage init time

### DIFF
--- a/charts/snapshotEngine/templates/configmap.yaml
+++ b/charts/snapshotEngine/templates/configmap.yaml
@@ -6,7 +6,7 @@ data:
   SNAPSHOT_MARKDOWN_TEMPLATE_URL: {{ $.Values.snapshotMarkdownTemplateUrl }}
   SERVICE_ACCOUNT: {{ $.Values.service_account }}
   RESTORED_STORAGE_INIT_TIME: {{ $.Values.restoredStorageInitTime }}
-  DISABLE_STORAGE_INIT_TIME: {{ $.Values.disableStorageInitTime }}
+  DISABLE_STORAGE_INIT_TIME: {{ $.Values.disableStorageInitTime | quote }}
 kind: ConfigMap
 metadata:
   name: snapshot-configmap

--- a/charts/snapshotEngine/templates/configmap.yaml
+++ b/charts/snapshotEngine/templates/configmap.yaml
@@ -5,6 +5,7 @@ data:
   TEZOS_IMAGE: {{ $.Values.images.octez }}
   SNAPSHOT_MARKDOWN_TEMPLATE_URL: {{ $.Values.snapshotMarkdownTemplateUrl }}
   SERVICE_ACCOUNT: {{ $.Values.service_account }}
+  RESTORED_STORAGE_INIT_TIME: {{ $.Values.restoredStorageInitTime }}
 kind: ConfigMap
 metadata:
   name: snapshot-configmap

--- a/charts/snapshotEngine/templates/configmap.yaml
+++ b/charts/snapshotEngine/templates/configmap.yaml
@@ -6,6 +6,7 @@ data:
   SNAPSHOT_MARKDOWN_TEMPLATE_URL: {{ $.Values.snapshotMarkdownTemplateUrl }}
   SERVICE_ACCOUNT: {{ $.Values.service_account }}
   RESTORED_STORAGE_INIT_TIME: {{ $.Values.restoredStorageInitTime }}
+  DISABLE_STORAGE_INIT_TIME: {{ $.Values.disableStorageInitTime }}
 kind: ConfigMap
 metadata:
   name: snapshot-configmap

--- a/charts/snapshotEngine/values.yaml
+++ b/charts/snapshotEngine/values.yaml
@@ -70,4 +70,4 @@ volumeSnapClass: ""
 restoredStorageInitTime: 2m
 
 # We also provide the ability to disable the time limit for debugging purposes.
-disableStorageInitTime: false
+disableStorageInitTime: "false"

--- a/charts/snapshotEngine/values.yaml
+++ b/charts/snapshotEngine/values.yaml
@@ -68,3 +68,6 @@ volumeSnapClass: ""
 # grows in size over time.
 # This time format is in unix sleep time format ex. 1s, 2m, 3h, 4d.
 restoredStorageInitTime: 2m
+
+# We also provide the ability to disable the time limit for debugging purposes.
+disableStorageInitTime: false

--- a/charts/snapshotEngine/values.yaml
+++ b/charts/snapshotEngine/values.yaml
@@ -57,3 +57,14 @@ snapshotMarkdownTemplateUrl: ""
 # you will have also created and named a volumeSnapshotClass that will be used in this value.
 # This value is used during the snapshot creation process.
 volumeSnapClass: ""
+
+# The EBS snapshot of a node is restored to a new volume as a part of the artifact generation process.  
+# This storage must have a tezos node "turned on" to initialize the storage for proper restoration later. 
+# However, there are errors that occur during this initialization due to Tezos not being tolerant 
+# of the KILL -9 that occurs during the EBS snapshot process.  
+# Tezos also does not exit on error, but rather just hangs stdout on a random error. 
+# Therefore we limit this initialization process and pitch the job in a reasonable amount of time to account for these
+# random errors. It may be necessary to increase this time for different changes, or as a particular chain
+# grows in size over time.
+# This time format is in unix sleep time format ex. 1s, 2m, 3h, 4d.
+restoredStorageInitTime: 2m

--- a/snapshotEngine/mainJob.yaml
+++ b/snapshotEngine/mainJob.yaml
@@ -45,7 +45,10 @@ spec:
               # Tezos does not exit on error so we have to time the job.
               # Configmaps can only have strings as keys, so we cant test for truthy values.
               if [ "${DISABLE_STORAGE_INIT_TIME}" != "true" ]; then
+                printf "%s Storage init time limit has NOT been disabled.  This job will be killed after %s\n" "$(date "+%Y-%m-%d %H:%M:%S" "$@")" "${RESTORED_STORAGE_INIT_TIME}"
                 sleep "${RESTORED_STORAGE_INIT_TIME}" && kill -s SIGINT 1 &
+              else
+                printf "%s Storage init time limit has been disabled. WARNING - This job will run indefinitely if there is an error.\n" "$(date "+%Y-%m-%d %H:%M:%S" "$@")"
               fi 
 
               # These loops wait on the RPC to come online and prevent log from printing same line

--- a/snapshotEngine/mainJob.yaml
+++ b/snapshotEngine/mainJob.yaml
@@ -43,7 +43,7 @@ spec:
               # Limit validation to restoredStorageInitTime. If this takes longer then there is a tezos error
               # and this job is tossed.
               # Tezos does not exit on error so we have to time the job.
-              if ! "${DISABLE_STORAGE_INIT_TIME}"; then
+              if [ "${DISABLE_STORAGE_INIT_TIME}" != "false" ]; then
                 sleep "${RESTORED_STORAGE_INIT_TIME}" && kill -s SIGINT 1 &
               fi 
 

--- a/snapshotEngine/mainJob.yaml
+++ b/snapshotEngine/mainJob.yaml
@@ -40,10 +40,10 @@ spec:
               # Run headless tezos node to validate storage on restored volume
               tezos-node run --connections 0 --config-file /home/tezos/.tezos-node/config.json --rpc-addr=127.0.0.1:8732 &
 
-              # Time validation to 2 minutes. If this takes longer then there is a tezos error
+              # Limit validation to restoredStorageInitTime. If this takes longer then there is a tezos error
               # and this job is tossed.
               # Tezos does not exit on error so we have to time the job.
-              sleep 2m && kill -s SIGINT 1 &
+              sleep "${RESTORED_STORAGE_INIT_TIME}" && kill -s SIGINT 1 &
 
               # These loops wait on the RPC to come online and prevent log from printing same line
               # over and over and over again.  This prints one line and waits for the RPC to come online for a clean log.
@@ -133,6 +133,11 @@ spec:
           env:
             - name: HISTORY_MODE
               value: ""
+            - name: RESTORED_STORAGE_INIT_TIME
+              valueFrom:
+                configMapKeyRef:
+                  name: snapshot-configmap
+                  key: RESTORED_STORAGE_INIT_TIME
             - name: NAMESPACE
               valueFrom:
                 configMapKeyRef:

--- a/snapshotEngine/mainJob.yaml
+++ b/snapshotEngine/mainJob.yaml
@@ -43,7 +43,8 @@ spec:
               # Limit validation to restoredStorageInitTime. If this takes longer then there is a tezos error
               # and this job is tossed.
               # Tezos does not exit on error so we have to time the job.
-              if [ "${DISABLE_STORAGE_INIT_TIME}" != "false" ]; then
+              # Configmaps can only have strings as keys, so we cant test for truthy values.
+              if [ "${DISABLE_STORAGE_INIT_TIME}" != "true" ]; then
                 sleep "${RESTORED_STORAGE_INIT_TIME}" && kill -s SIGINT 1 &
               fi 
 

--- a/snapshotEngine/mainJob.yaml
+++ b/snapshotEngine/mainJob.yaml
@@ -43,7 +43,9 @@ spec:
               # Limit validation to restoredStorageInitTime. If this takes longer then there is a tezos error
               # and this job is tossed.
               # Tezos does not exit on error so we have to time the job.
-              sleep "${RESTORED_STORAGE_INIT_TIME}" && kill -s SIGINT 1 &
+              if ! "${DISABLE_STORAGE_INIT_TIME}"; then
+                sleep "${RESTORED_STORAGE_INIT_TIME}" && kill -s SIGINT 1 &
+              fi 
 
               # These loops wait on the RPC to come online and prevent log from printing same line
               # over and over and over again.  This prints one line and waits for the RPC to come online for a clean log.
@@ -138,6 +140,11 @@ spec:
                 configMapKeyRef:
                   name: snapshot-configmap
                   key: RESTORED_STORAGE_INIT_TIME
+            - name: DISABLE_STORAGE_INIT_TIME
+              valueFrom:
+                configMapKeyRef:
+                  name: snapshot-configmap
+                  key: DISABLE_STORAGE_INIT_TIME
             - name: NAMESPACE
               valueFrom:
                 configMapKeyRef:


### PR DESCRIPTION
# Overview
This PR provides the ability for a user to set the time limit for the storage initialization container. 

# Background
This container starts a headless Tezos node and initializes the storage restored from an EBS snapshot. This is necessary to account for missing head blocks that frequently occur.  This is done for both rolling and archive tarballs, and Tezos snapshot workflows.

# Details
We've added the `restoredStorageInitTime`, `disableStorageInitTime` of which default to `2m` and `false` respectively.

2m has been plenty of time for testnets and mainnet in the past, but now it seems that mainnet might need more time to init storage as it has been a few days since a successful job.

Upon investigation it seems that all the jobs are killed during the head reconstruction, so it must mean that we need more time to let the head rebuild on mainnet.

In the future it may be necessary to let the job run without being killed to determine a proper init time, so the ability to disable the time limit has also bee implemented.