### PR TITLE
Make remote signer secure

### DIFF
--- a/charts/tezos/scripts/remote-signer.sh
+++ b/charts/tezos/scripts/remote-signer.sh
@@ -6,6 +6,6 @@ CLIENT_DIR="$TEZ_VAR/client"
 NODE_DIR="$TEZ_VAR/node"
 NODE_DATA_DIR="$TEZ_VAR/node/data"
 
-CMD="$TEZ_BIN/tezos-signer -d $CLIENT_DIR launch http signer -a 0.0.0.0 -p 6732"
+CMD="$TEZ_BIN/tezos-signer -d $CLIENT_DIR launch http signer --magic-bytes 0x11,0x12,0x13 --check-high-watermark -a 0.0.0.0 -p 6732"
 
 exec $CMD


### PR DESCRIPTION
Right now, when configuring tezos-k8s with a remote signer, you can
still sign transfers from the node shell, or by connecting to the signer
endpoint. This PR makes the signer only allow bakes, endorses and
preendorses, by restricting it to the magic bytes 11-12-13. It's not
much (you can still shell in to the signer and transfer whatever you
like) but it's a start.

I am also enforcing high watermark while we are at it.

I tested in a private chain and was able to verify that it still bakes
and endorses, but transfers from the node shell fail with:

```
magic byte 0x03 not allowed
Fatal error:
transfer simulation failed
~ $
```