### PR TITLE
repair zerotier

### DIFF
--- a/zerotier/Dockerfile
+++ b/zerotier/Dockerfile
@@ -1,37 +1,37 @@
 FROM alpine
 
-ENV ZEROTIER_VERSION=1.4.6
+ENV ZEROTIER_VERSION=1.6.6
 
 RUN set -eux; \
-    apk add --no-cache \
-      libgcc \
-      libstdc++ \
-    ; \
-    apk add --no-cache --virtual build-dependencies \
-      build-base \
-      linux-headers \
-    ; \
-    apk add --update supervisor \
-        bash \
-        iptables\
-        openrc \
-        curl \
-        jq \
-    ;\
-    wget https://github.com/zerotier/ZeroTierOne/archive/$ZEROTIER_VERSION.zip -O /zerotier.zip; \
-    unzip /zerotier.zip -d /; \
-    cd /ZeroTierOne-$ZEROTIER_VERSION; \
-    make; \
-    DESTDIR=/tmp/build make install; \
-    mv /tmp/build/usr/sbin/* /usr/sbin/; \
-    mkdir /var/lib/zerotier-one; \
-    apk del build-dependencies; \
-    rm -rf /tmp/build; \
-    rm -rf /ZeroTierOne-$ZEROTIER_VERSION; \
-    rm -rf /zerotier.zip; \
-    zerotier-one -v; \
-    rc-update add iptables ;\
-    echo "tun" >> /etc/modules
+  apk add --no-cache \
+  libgcc \
+  libstdc++ \
+  ; \
+  apk add --no-cache --virtual build-dependencies \
+  build-base \
+  linux-headers \
+  ; \
+  apk add --update supervisor \
+  bash \
+  iptables\
+  openrc \
+  curl \
+  jq \
+  ;\
+  wget https://github.com/zerotier/ZeroTierOne/archive/$ZEROTIER_VERSION.zip -O /zerotier.zip; \
+  unzip /zerotier.zip -d /; \
+  cd /ZeroTierOne-$ZEROTIER_VERSION; \
+  make; \
+  DESTDIR=/tmp/build make install; \
+  mv /tmp/build/usr/sbin/* /usr/sbin/; \
+  mkdir /var/lib/zerotier-one; \
+  apk del build-dependencies; \
+  rm -rf /tmp/build; \
+  rm -rf /ZeroTierOne-$ZEROTIER_VERSION; \
+  rm -rf /zerotier.zip; \
+  zerotier-one -v; \
+  rc-update add iptables ;\
+  echo "tun" >> /etc/modules
 
 
 COPY supervisor-zerotier.conf /etc/supervisor/supervisord.conf

--- a/zerotier/entrypoint.sh
+++ b/zerotier/entrypoint.sh
@@ -13,7 +13,7 @@ supervisord -c /etc/supervisor/supervisord.conf
 # waiting for Zerotier IP
 # why 2? because you have an ipv6 and an a ipv4 address by default if everything is ok
 IP_OK=0
-while [ $IP_OK -lt 1 ]
+while [ $IP_OK -lt 2 ]
 do
   ZTDEV=$( ip addr | grep -i zt | grep -i mtu | awk '{ print $2 }' | cut -f1 -d':' | tail -1 )
   IP_OK=$( ip addr show dev $ZTDEV | grep -i inet | wc -l )


### PR DESCRIPTION
I found zerotier not working when testing #393

After debugging, it looks like it was not waiting for the ipv4 address
to be present before attempting to parse it.

There is logic to wait for the ipv4 addres to be present, by conuting
the number of inet strings in the output of ip a. It was meant to match
a 2, but it matches a 1, for some reason. Setting the value to 2 fixes
it.

Also bump zerotier version to 1.6 (latest is 1.8 but it requires rust
dependencies, so 1.6 sounds good enough).