### PR TITLE
remove unsafe disclaimer from mkchain chains

### DIFF
--- a/mkchain/tqchain/mkchain.py
+++ b/mkchain/tqchain/mkchain.py
@@ -162,6 +162,9 @@ def main():
         "rolling_snapshot_url": None,
         "archive_tarball_url": None,
         "rolling_tarball_url": None,
+        "node_globals": {
+            "env": {"all": {"TEZOS_CLIENT_UNSAFE_DISABLE_DISCLAIMER": "Y"}}
+        },
     }
 
     # preserve pre-existing values, if any (in case of scale-up)


### PR DESCRIPTION
make sure that mkchain nodes have the environment variable set that
removes the annoying disclaimer each time you type a command. For a
private chain, this makes sense.

Nice to have after merging #393