### PR TITLE
Fix config init

### DIFF
--- a/charts/tezos/templates/_containers.tpl
+++ b/charts/tezos/templates/_containers.tpl
@@ -174,6 +174,7 @@
     {{- include "tezos.generic_container" (dict "root"        $
                                                 "type"        "config-init"
                                                 "image"       "octez"
+                                                "with_config" 1
                                                 "localvars"   1
     ) | nindent 0 }}
   {{- end }}

--- a/test/charts/mainnet.expect.yaml
+++ b/test/charts/mainnet.expect.yaml
@@ -210,6 +210,8 @@ spec:
               printf "\n\n\n\n\n\n\n"
               
           envFrom:
+            - configMapRef:
+                name: tezos-config
           env:    
             - name: MY_POD_IP
               valueFrom:

--- a/test/charts/mainnet2.expect.yaml
+++ b/test/charts/mainnet2.expect.yaml
@@ -307,6 +307,8 @@ spec:
               printf "\n\n\n\n\n\n\n"
               
           envFrom:
+            - configMapRef:
+                name: tezos-config
           env:    
             - name: MY_POD_IP
               valueFrom:
@@ -662,6 +664,8 @@ spec:
               printf "\n\n\n\n\n\n\n"
               
           envFrom:
+            - configMapRef:
+                name: tezos-config
           env:    
             - name: MY_POD_IP
               valueFrom:


### PR DESCRIPTION
fix public chains after https://github.com/oxheadalpha/tezos-k8s/pull/393: config-init needs access to the variable `$CHAIN_NAME`.

This broke oxheadinfra.