### PR TITLE
aggressive refactoring of signer

### DIFF
--- a/charts/tezos/scripts/signer.sh
+++ b/charts/tezos/scripts/signer.sh
@@ -6,6 +6,6 @@ CLIENT_DIR="$TEZ_VAR/client"
 NODE_DIR="$TEZ_VAR/node"
 NODE_DATA_DIR="$TEZ_VAR/node/data"
 
-CMD="$TEZ_BIN/tezos-signer -d $CLIENT_DIR launch http signer --magic-bytes 0x11,0x12,0x13 --check-high-watermark -a 0.0.0.0 -p 6732"
+CMD="$TEZ_BIN/tezos-signer -d $CLIENT_DIR launch http signer ${SIGNER_EXTRA_ARGS} --check-high-watermark -a 0.0.0.0 -p 6732"
 
 exec $CMD

--- a/charts/tezos/templates/_containers.tpl
+++ b/charts/tezos/templates/_containers.tpl
@@ -8,7 +8,7 @@
     fieldRef:
       fieldPath: metadata.name
 - name: MY_POD_TYPE
-  value: node
+  value: {{ .pod_type }}
   {{- if hasKey . "node_class" }}
 - name: MY_NODE_CLASS
   value: {{ .node_class }}
@@ -337,6 +337,17 @@
     - name: DAEMON
       value: tezos-metrics
 {{- end }}
+{{- end }}
+
+{{- define "tezos.container.signer" }}
+  {{- if include "tezos.shouldDeploySignerStatefulset" . }}
+    {{- include "tezos.generic_container" (dict "root"   $
+                                           "type"        "signer"
+                                           "image"       "octez"
+                                           "with_config" 1
+                                           "localvars"   1
+    )  | nindent 0 }}
+  {{- end }}
 {{- end }}
 
 {{/*

--- a/charts/tezos/templates/nodes.yaml
+++ b/charts/tezos/templates/nodes.yaml
@@ -3,6 +3,7 @@
   {{- $_ := set $ "node_class" $key }}
   {{- $_ := set $ "node_vals" $val }}
   {{- $_ := set $ "node_identities" dict }}
+  {{- $_ := set $ "pod_type" "node" }}
 
   {{- include "tezos.includeNodeIdentitySecret" $ }}
 

--- a/charts/tezos/templates/signer.yaml
+++ b/charts/tezos/templates/signer.yaml
@@ -1,58 +1,31 @@
-{{- if (include "tezos.shouldDeploySignerStatefulset" .) }}
+{{- range $key, $val := .Values.signers }}
+{{- if $val }}
+  {{- $_ := set $ "node_class" $key }}
+  {{- $_ := set $ "node_vals" $val }}
+  {{- $_ := set $ "node_identities" dict }}
+  {{- $_ := set $ "pod_type" "signing" }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ .Values.signer_statefulset.name }}
-  namespace: {{ .Release.Namespace }}
+  name: {{ $.node_class }}
+  namespace: {{ $.Release.Namespace }}
 spec:
   podManagementPolicy: Parallel
-  replicas: {{ .Values.signers | len }}
-  serviceName: {{ .Values.signer_statefulset.name }}
+  replicas: {{ $.node_vals.instances | len }}
+  serviceName: {{ $.node_class }}
   selector:
     matchLabels:
-      app: {{ .Values.signer_statefulset.name }}
+      node_class: {{ $.node_class }}
   template:
     metadata:
       labels:
-        app: {{ .Values.signer_statefulset.name }}
+        appType: tezos-signer
+        node_class: {{ $.node_class }}
     spec:
       containers:
-      - name: tezos-signer
-        image: "{{ .Values.images.octez }}"
-        imagePullPolicy: IfNotPresent
-        ports:
-        - containerPort: 6732
-          name: signer
-        command:
-          - /bin/sh
-        volumeMounts:
-        - mountPath: /var/tezos
-          name: var-volume
-        args:
-          - "-c"
-          - |
-{{ tpl (.Files.Get "scripts/remote-signer.sh") $ | indent 12 }}
+        {{- include "tezos.container.signer"      $ | indent 8 }}
       initContainers:
-      - image: {{ .Values.tezos_k8s_images.utils }}
-        imagePullPolicy: IfNotPresent
-        name: config-generator
-        args:
-          - "config-generator"
-        envFrom:
-          - configMapRef:
-              name: tezos-config
-        env:
-          - name: MY_POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: MY_POD_TYPE
-            value: {{ .Values.signer_statefulset.pod_type }}
-        volumeMounts:
-          - mountPath: /var/tezos
-            name: var-volume
-          - mountPath: /etc/secret-volume
-            name: tezos-accounts
+        {{- include "tezos.init_container.config_generator"    $ | indent 8 }}
       securityContext:
         fsGroup: 100
       volumes:
@@ -61,18 +34,16 @@ spec:
         - name: tezos-accounts
           secret:
             secretName: tezos-secret
+      securityContext:
+        fsGroup: 100
+      volumes:
+        - emptyDir: {}
+          name: var-volume
+        - emptyDir: {}
+          name: config-volume
+        - name: tezos-accounts
+          secret:
+            secretName: tezos-secret
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  name: {{ .Values.signer_statefulset.name }}
-  namespace: {{ .Release.Namespace }}
-spec:
-  clusterIP: None
-  ports:
-    - port: 6732
-      name: signer
-  selector:
-    app: {{ .Values.signer_statefulset.name }}
----
+{{- end }}
 {{- end }}

--- a/charts/tezos/templates/static.yaml
+++ b/charts/tezos/templates/static.yaml
@@ -25,6 +25,18 @@ spec:
     node_class: {{ $key }}
 ---
 {{- end }}
+{{- range $key, $val := .Values.signers }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $key }}
+spec:
+  publishNotReadyAddresses: true
+  clusterIP: None
+  selector:
+    node_class: {{ $key }}
+---
+{{- end }}
 {{- if (include "tezos.shouldDeployTzktIndexer" .) }}
 apiVersion: v1
 kind: Service

--- a/charts/tezos/values.yaml
+++ b/charts/tezos/values.yaml
@@ -217,10 +217,16 @@ services:
 
 # Define and use external remote signers.
 # Bakers automatically use signers when configured.
+# Pass extra args if needed. The example below restricts signing to consensus
+# operations.
 signers: {}
-#  tezos-signer-0:
-#    sign_for_accounts:
-#    - baker0
+#  tezos-signer:
+#    env:
+#      all:
+#        SIGNER_EXTRA_ARGS: --magic-byte 0x11,0x12,0x13
+#    instances:
+#    - sign_for_accounts:
+#      - baker0
 
 ## Where full and rolling history mode nodes will get their Tezos snapshots from.
 full_snapshot_url: https://mainnet.xtz-shots.io/full

--- a/mkchain/tqchain/mkchain.py
+++ b/mkchain/tqchain/mkchain.py
@@ -253,10 +253,16 @@ def main():
         }
 
     signers = {
-        "tezos-signer-0": {
-            "sign_for_accounts": [
-                f"{ARCHIVE_BAKER_NODE_NAME}-{n}" for n in range(args.number_of_bakers)
-            ]
+        "tezos-signer": {
+            "env": {"SIGNER_EXTRA_ARGS": "--magic-bytes 0x11,0x12,0x13"},
+            "instances": [
+                {
+                    "sign_for_accounts": [
+                        f"{ARCHIVE_BAKER_NODE_NAME}-{n}"
+                        for n in range(args.number_of_bakers)
+                    ]
+                }
+            ],
         }
     }
 

--- a/test/charts/private-chain.expect.yaml
+++ b/test/charts/private-chain.expect.yaml
@@ -162,8 +162,12 @@ data:
   SIGNERS: |
     {
       "tezos-signer-0": {
-        "sign_for_accounts": [
-          "tezos-baking-node-0"
+        "instances": [
+          {
+            "sign_for_accounts": [
+              "tezos-baking-node-0"
+            ]
+          }
         ]
       }
     }
@@ -171,20 +175,6 @@ kind: ConfigMap
 metadata:
   name: tezos-config
   namespace: testing
----
-# Source: tezos-chain/templates/signer.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: tezos-signer
-  namespace: testing
-spec:
-  clusterIP: None
-  ports:
-    - port: 6732
-      name: signer
-  selector:
-    app: tezos-signer
 ---
 # Source: tezos-chain/templates/static.yaml
 apiVersion: v1
@@ -243,6 +233,17 @@ spec:
   clusterIP: None
   selector:
     node_class: us
+---
+# Source: tezos-chain/templates/static.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: tezos-signer-0
+spec:
+  publishNotReadyAddresses: true
+  clusterIP: None
+  selector:
+    node_class: tezos-signer-0
 ---
 # Source: tezos-chain/templates/nodes.yaml
 apiVersion: apps/v1
@@ -1163,73 +1164,111 @@ spec:
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: tezos-signer
+  name: tezos-signer-0
   namespace: testing
 spec:
   podManagementPolicy: Parallel
   replicas: 1
-  serviceName: tezos-signer
+  serviceName: tezos-signer-0
   selector:
     matchLabels:
-      app: tezos-signer
+      node_class: tezos-signer-0
   template:
     metadata:
       labels:
-        app: tezos-signer
+        appType: tezos-signer
+        node_class: tezos-signer-0
     spec:
-      containers:
-      - name: tezos-signer
-        image: "tezos/tezos:v12-release"
-        imagePullPolicy: IfNotPresent
-        ports:
-        - containerPort: 6732
-          name: signer
-        command:
-          - /bin/sh
-        volumeMounts:
-        - mountPath: /var/tezos
-          name: var-volume
-        args:
-          - "-c"
-          - |
-            set -ex
-            
-            TEZ_VAR=/var/tezos
-            TEZ_BIN=/usr/local/bin
-            CLIENT_DIR="$TEZ_VAR/client"
-            NODE_DIR="$TEZ_VAR/node"
-            NODE_DATA_DIR="$TEZ_VAR/node/data"
-            
-            CMD="$TEZ_BIN/tezos-signer -d $CLIENT_DIR launch http signer --magic-bytes 0x11,0x12,0x13 --check-high-watermark -a 0.0.0.0 -p 6732"
-            
-            exec $CMD
-            
-      initContainers:
-      - image: tezos-k8s-utils:dev
-        imagePullPolicy: IfNotPresent
-        name: config-generator
-        args:
-          - "config-generator"
-        envFrom:
-          - configMapRef:
-              name: tezos-config
-        env:
-          - name: MY_POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: MY_POD_TYPE
-            value: signing
-        volumeMounts:
-          - mountPath: /var/tezos
-            name: var-volume
-          - mountPath: /etc/secret-volume
-            name: tezos-accounts
+      containers:        
+        - name: signer
+          image: "tezos/tezos:v12-release"
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+          args:
+            - "-c"
+            - |
+              set -ex
+              
+              TEZ_VAR=/var/tezos
+              TEZ_BIN=/usr/local/bin
+              CLIENT_DIR="$TEZ_VAR/client"
+              NODE_DIR="$TEZ_VAR/node"
+              NODE_DATA_DIR="$TEZ_VAR/node/data"
+              
+              CMD="$TEZ_BIN/tezos-signer -d $CLIENT_DIR launch http signer ${SIGNER_EXTRA_ARGS} --check-high-watermark -a 0.0.0.0 -p 6732"
+              
+              exec $CMD
+              
+          envFrom:
+            - configMapRef:
+                name: tezos-config
+          env:    
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MY_POD_TYPE
+              value: signing
+            - name: MY_NODE_CLASS
+              value: tezos-signer-0
+            - name: DAEMON
+              value: signer
+          volumeMounts:
+            - mountPath: /etc/tezos
+              name: config-volume
+            - mountPath: /var/tezos
+              name: var-volume
+      initContainers:        
+        - name: config-generator
+          image: "tezos-k8s-utils:dev"
+          imagePullPolicy: IfNotPresent
+          args:
+            - config-generator
+          envFrom:
+            - configMapRef:
+                name: tezos-config
+          env:    
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MY_POD_TYPE
+              value: signing
+            - name: MY_NODE_CLASS
+              value: tezos-signer-0
+            - name: DAEMON
+              value: config-generator
+          volumeMounts:
+            - mountPath: /etc/tezos
+              name: config-volume
+            - mountPath: /var/tezos
+              name: var-volume
+            - mountPath: /etc/secret-volume
+              name: tezos-accounts
       securityContext:
         fsGroup: 100
       volumes:
         - emptyDir: {}
           name: var-volume
+        - name: tezos-accounts
+          secret:
+            secretName: tezos-secret
+      securityContext:
+        fsGroup: 100
+      volumes:
+        - emptyDir: {}
+          name: var-volume
+        - emptyDir: {}
+          name: config-volume
         - name: tezos-accounts
           secret:
             secretName: tezos-secret

--- a/test/charts/private-chain.in.yaml
+++ b/test/charts/private-chain.in.yaml
@@ -98,6 +98,7 @@ rolling_snapshot_url: null
 should_generate_unsafe_deterministic_data: true
 signers:
   tezos-signer-0:
-    sign_for_accounts: [tezos-baking-node-0]
+    instances:
+    - sign_for_accounts: [tezos-baking-node-0]
 zerotier_config: {zerotier_network: null, zerotier_token: null}
 open_acls: true

--- a/utils/config-generator.py
+++ b/utils/config-generator.py
@@ -29,6 +29,7 @@ MY_POD_TYPE = os.environ["MY_POD_TYPE"]
 MY_POD_CLASS = {}
 MY_POD_CONFIG = {}
 ALL_NODES = {}
+ALL_SIGNERS = {}
 BAKING_NODES = {}
 
 for cl, val in NODES.items():
@@ -43,8 +44,14 @@ for cl, val in NODES.items():
                 if "baker" in val["runs"]:
                     BAKING_NODES[name] = inst
 
-if MY_POD_TYPE == "signing":
-    MY_POD_CONFIG = SIGNERS[MY_POD_NAME]
+for cl, val in SIGNERS.items():
+    if val != None:
+        for i, inst in enumerate(val["instances"]):
+            name = f"{cl}-{i}"
+            ALL_SIGNERS[name] = inst
+            if name == MY_POD_NAME:
+                MY_POD_CLASS = val
+                MY_POD_CONFIG = inst
 
 NETWORK_CONFIG = CHAIN_PARAMS["network"]
 
@@ -333,7 +340,7 @@ def pod_requires_secret_key(account_name):
 
 
 def remote_signer(account_name, key):
-    for k, v in SIGNERS.items():
+    for k, v in ALL_SIGNERS.items():
         if account_name in v["sign_for_accounts"]:
             return f"http://{k}.tezos-signer:6732/{key.public_key_hash()}"
     return None


### PR DESCRIPTION
This is a continuation of @elric1's aggressive refactoring of the node
templating. We are defining signers using _containers.tpl in a generic
way. This results in less code and easier to understand. Plus, we get
the ability to set env variables "for free".

The env var change was my original intent: I need to parametrize magic
bytes differently based on the network type. Instead of making a
custom parameter, I allow a generic $SIGNER_EXTRA_ARGS parameter which I
can use to set magic bytes or anything else.

This results in a change in values.yaml (and will require a major
version bump). We are now defining signers exactly like nodes, as a map
of statefulsets. Each statefulset contains an `instances` list where we
define values custom to each pod:

```
signers:
  tezos-signer:
    env:
      all:
        SIGNER_EXTRA_ARGS: --magic-byte 0x11,0x12,0x13
    instances:
    - sign_for_accounts:
      - baker0
```

While previously it was:

```
signers:
  tezos-signer-0:
    sign_for_accounts:
    - baker0
```

This allows signers to be configured exactly like nodes, which is more
intuitive for the tezos-k8s user.