### PR TITLE
Deprecate 'type' field in accounts

### DIFF
--- a/charts/tezos/templates/NOTES.txt
+++ b/charts/tezos/templates/NOTES.txt
@@ -1,0 +1,5 @@
+{{- range $k, $v := .Values.accounts }}
+  {{- if $v.type }}
+DEPRECATION WARNING: You specified a type for account {{ $k }}. This field is now ignored, the type of key is set automatically.
+  {{- end }}
+{{- end }}

--- a/charts/tezos/templates/configs.yaml
+++ b/charts/tezos/templates/configs.yaml
@@ -60,7 +60,11 @@ metadata:
 apiVersion: v1
 data:
   ACCOUNTS: |
-{{ .Values.accounts | toJson | b64enc | indent 4 }}
+{{- $accounts := dict }}
+{{- range $k, $v := .Values.accounts }}
+  {{- $_ := set $accounts $k (omit $v "type" ) }}
+{{- end }}
+{{ $accounts | toJson | b64enc | indent 4 }}
 kind: Secret
 metadata:
   name: tezos-secret

--- a/charts/tezos/values.yaml
+++ b/charts/tezos/values.yaml
@@ -48,16 +48,18 @@ should_generate_unsafe_deterministic_data: false
 #   node but they will not be bootstrap accounts. If you don't set a bootstrap
 #   balance, it will default to the `bootstrap_mutez` field above.
 #
+#  The key field can be set to a public or private key. For a bootstrap baker,
+#  it must be set to a private key. The key type will be recognized automatically,
+#  and the pod will fail if the key type is unexpected.
+#
 accounts: {}
 #   baker0:
 #     key: edsk...
-#     type: secret
 #     is_bootstrap_baker_account: true
 #     bootstrap_balance: "50000000000000"
 
 #   baker1:
 #     key: edpk...
-#     type: public
 #     is_bootstrap_baker_account: false
 #     bootstrap_balance: "4000000000000"
 

--- a/mkchain/tqchain/mkchain.py
+++ b/mkchain/tqchain/mkchain.py
@@ -225,7 +225,6 @@ def main():
             for key_type in keys:
                 accounts[key_type][account] = {
                     "key": keys[key_type],
-                    "type": key_type,
                     "is_bootstrap_baker_account": True,
                     "bootstrap_balance": "4000000000000",
                 }

--- a/utils/config-generator.py
+++ b/utils/config-generator.py
@@ -275,15 +275,9 @@ def fill_in_missing_keys(all_accounts):
     print("\nFill in missing keys")
 
     for account_name, account_values in all_accounts.items():
-        account_key_type = account_values.get("type")
+        if "type" in account_values:
+            raise Exception("Deprecated field 'type' passed by helm, but helm should have pruned it.")
         account_key = account_values.get("key")
-
-        if account_key == None and account_key_type != None:
-            raise Exception(
-                f"ERROR: {account_name} specifies "
-                + f"type {account_key_type} without "
-                + f"a key"
-            )
 
         if account_key == None:
             print(
@@ -348,7 +342,6 @@ def import_keys(all_accounts):
 
     for account_name, account_values in all_accounts.items():
         print("\n  Importing keys for account: " + account_name)
-        account_key_type = account_values.get("type")
         account_key = account_values.get("key")
 
         if account_key == None:
@@ -359,16 +352,8 @@ def import_keys(all_accounts):
             key.secret_key()
         except ValueError:
             account_values["type"] = "public"
-            if account_key_type == "secret":
-                raise ValueError(
-                    account_name + "'s key marked as " + "secret, but it is public"
-                )
         else:
             account_values["type"] = "secret"
-            if account_key_type == "public":
-                raise ValueError(
-                    account_name + "'s key marked as " + "public, but it is secret"
-                )
 
         # restrict which private key is exposed to which pod
         if expose_secret_key(account_name):


### PR DESCRIPTION
This field was previously used by config_generator, but @elric1 changed
the code to infer the key type from the string.

We are deprecating this field and throwing a helm message when it's
found. It is pruned by helm and no longer passed to config_generator.

In a later release, we can fail the chart install when it is found.

I tried:

* mkchain, no params
* mkchain, 2 bakers
* mkchain with old "type" field: gives me a warning, ignores content of
  field
* mkchain then delete private keys; observe they are reconstructed
  deterministically when unsafe setting in values.yaml is set to true
* pass an actual public key as non bootstrap baker