### PR TITLE
symlink octez signer dir to default place

### DIFF
--- a/charts/tezos/scripts/remote-signer.sh
+++ b/charts/tezos/scripts/remote-signer.sh
@@ -8,4 +8,7 @@ NODE_DATA_DIR="$TEZ_VAR/node/data"
 
 CMD="$TEZ_BIN/tezos-signer -d $CLIENT_DIR launch http signer --magic-bytes 0x11,0x12,0x13 --check-high-watermark -a 0.0.0.0 -p 6732"
 
+# ensure we can run tezos-signer commands without specifying client dir
+ln -s /var/tezos/client /home/tezos/.tezos-signer
+
 exec $CMD

--- a/test/charts/private-chain.expect.yaml
+++ b/test/charts/private-chain.expect.yaml
@@ -1202,6 +1202,9 @@ spec:
             
             CMD="$TEZ_BIN/tezos-signer -d $CLIENT_DIR launch http signer --magic-bytes 0x11,0x12,0x13 --check-high-watermark -a 0.0.0.0 -p 6732"
             
+            # ensure we can run tezos-signer commands without specifying client dir
+            ln -s /var/tezos/client /home/tezos/.tezos-signer
+            
             exec $CMD
             
       initContainers:


### PR DESCRIPTION
so one can open a shell into the signer, and run

```
tezos-signer list known addresses
```
and see the addresses in the output, without passing an actual data dir.

in the spirit of #369, but for the signer