### PR TITLE
Revert "chain-initiator.sh: piping to head loses error status"

### DIFF
--- a/charts/tezos/scripts/chain-initiator.sh
+++ b/charts/tezos/scripts/chain-initiator.sh
@@ -17,4 +17,4 @@ $CLIENT -d /var/tezos/client --block					\
 	{{ .Values.activation.protocol_hash }}				\
 	with fitness -1 and key						\
 	$( cat /etc/tezos/activation_account_name )			\
-	and parameters /etc/tezos/parameters.json
+	and parameters /etc/tezos/parameters.json 2>&1 | head -200

--- a/test/charts/private-chain.expect.yaml
+++ b/test/charts/private-chain.expect.yaml
@@ -1276,7 +1276,7 @@ spec:
               	Psithaca2MLRFYargivpo7YvUr7wUDqyxrdhC5CQq78mRvimz6A				\
               	with fitness -1 and key						\
               	$( cat /etc/tezos/activation_account_name )			\
-              	and parameters /etc/tezos/parameters.json
+              	and parameters /etc/tezos/parameters.json 2>&1 | head -200
               
           envFrom:
           env:


### PR DESCRIPTION
This reverts commit 9e9517c02a2c0c05cec80dabfdb4f0d3f2701653.

Turns out that because pipefail is set, that this commit is incorrect.
I did issues w.r.t. this in testing, but must have been on a branch or
perhaps an older image with a different /bin/sh as I can't reproduce
them any more.