### PR TITLE
add an env variable for arbitrary extra baker arg passing

### DIFF
--- a/charts/tezos/scripts/baker.sh
+++ b/charts/tezos/scripts/baker.sh
@@ -5,6 +5,7 @@ TEZ_BIN=/usr/local/bin
 CLIENT_DIR="$TEZ_VAR/client"
 NODE_DIR="$TEZ_VAR/node"
 NODE_DATA_DIR="$TEZ_VAR/node/data"
+BAKER_EXTRA_ARGS_FROM_ENV=${BAKER_EXTRA_ARGS}
 
 proto_command="{{ .command_in_tpl }}"
 
@@ -28,4 +29,4 @@ while ! $CLIENT rpc get chains/main/blocks/head; do
     sleep 5
 done
 
-exec $CMD run with local node $NODE_DATA_DIR ${extra_args} ${my_baker_account}
+exec $CMD run with local node $NODE_DATA_DIR ${extra_args} ${BAKER_EXTRA_ARGS_FROM_ENV} ${my_baker_account}

--- a/test/charts/private-chain.expect.yaml
+++ b/test/charts/private-chain.expect.yaml
@@ -305,6 +305,7 @@ spec:
               CLIENT_DIR="$TEZ_VAR/client"
               NODE_DIR="$TEZ_VAR/node"
               NODE_DATA_DIR="$TEZ_VAR/node/data"
+              BAKER_EXTRA_ARGS_FROM_ENV=${BAKER_EXTRA_ARGS}
               
               proto_command="012-Psithaca"
               
@@ -328,7 +329,7 @@ spec:
                   sleep 5
               done
               
-              exec $CMD run with local node $NODE_DATA_DIR ${extra_args} ${my_baker_account}
+              exec $CMD run with local node $NODE_DATA_DIR ${extra_args} ${BAKER_EXTRA_ARGS_FROM_ENV} ${my_baker_account}
               
           envFrom:
           env:
@@ -750,6 +751,7 @@ spec:
               CLIENT_DIR="$TEZ_VAR/client"
               NODE_DIR="$TEZ_VAR/node"
               NODE_DATA_DIR="$TEZ_VAR/node/data"
+              BAKER_EXTRA_ARGS_FROM_ENV=${BAKER_EXTRA_ARGS}
               
               proto_command="012-Psithaca"
               
@@ -773,7 +775,7 @@ spec:
                   sleep 5
               done
               
-              exec $CMD run with local node $NODE_DATA_DIR ${extra_args} ${my_baker_account}
+              exec $CMD run with local node $NODE_DATA_DIR ${extra_args} ${BAKER_EXTRA_ARGS_FROM_ENV} ${my_baker_account}
               
           envFrom:
           env:
@@ -1028,6 +1030,7 @@ spec:
               CLIENT_DIR="$TEZ_VAR/client"
               NODE_DIR="$TEZ_VAR/node"
               NODE_DATA_DIR="$TEZ_VAR/node/data"
+              BAKER_EXTRA_ARGS_FROM_ENV=${BAKER_EXTRA_ARGS}
               
               proto_command="012-Psithaca"
               
@@ -1051,7 +1054,7 @@ spec:
                   sleep 5
               done
               
-              exec $CMD run with local node $NODE_DATA_DIR ${extra_args} ${my_baker_account}
+              exec $CMD run with local node $NODE_DATA_DIR ${extra_args} ${BAKER_EXTRA_ARGS_FROM_ENV} ${my_baker_account}
               
           envFrom:
           env:


### PR DESCRIPTION
This is handy and has multiple uses. No need to modify the chart to pass
a special argument, just set the env var in values.yaml

Example usage:

```
  flashbake-baker-1:
    env:
      baker:
        BAKER_EXTRA_ARGS: "--operations-pool http://flashbake-endpoint-1:12732/operations-pool"
    instances:
    - bake_using_accounts:
      - flashbake-baker-1
```