### PR TITLE
fix baseUrl for docusaurus

### DIFF
--- a/.github/workflows/docusaurus.yml
+++ b/.github/workflows/docusaurus.yml
@@ -3,6 +3,7 @@ name: docusaurus
 on:
   release:
     types: [created]
+  pull_request:
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/docusaurus.yml
+++ b/.github/workflows/docusaurus.yml
@@ -3,7 +3,6 @@ name: docusaurus
 on:
   release:
     types: [created]
-  pull_request:
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -8,8 +8,8 @@ const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 const config = {
   title: 'Tezos K8s',
   tagline: 'Deploy a Tezos Blockchain on Kubernetes',
-  url: 'https://oxheadalpha.com',
-  baseUrl: '/tezos-k8s/',
+  url: 'https://tezos-k8s.xyz',
+  baseUrl: '/',
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
   favicon: 'img/favicon.ico',

--- a/docs/values_to_doc.sh
+++ b/docs/values_to_doc.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 extract_markdown() {
   uncommented=false


### PR DESCRIPTION
now that docusaurus is deployed to tezos-k8s.xyz, we need to change the base url

also fix interpreter for the markdown generation logic