### PR TITLE
fix network override value

### DIFF
--- a/charts/snapshotEngine/templates/configmap.yaml
+++ b/charts/snapshotEngine/templates/configmap.yaml
@@ -10,7 +10,7 @@ data:
   SERVICE_ACCOUNT: {{ $.Values.service_account }}
   RESTORED_STORAGE_INIT_TIME: {{ $.Values.restoredStorageInitTime }}
   DISABLE_STORAGE_INIT_TIME: {{ $.Values.disableStorageInitTime | quote }}
-  NETWORK: {{ $.Values.network }}
+  NETWORK_OVERRIDE: {{ $.Values.networkOverride | default "" | quote }}
 kind: ConfigMap
 metadata:
   name: snapshot-configmap

--- a/charts/snapshotEngine/values.yaml
+++ b/charts/snapshotEngine/values.yaml
@@ -90,4 +90,4 @@ disableStorageInitTime: "false"
 # Used to start the snapshotable node, and for the initialization network on the restored snapshot.
 # Can be useful if namespace does not begin with network name.
 # Optional, defaults to beginning word of namespace before "-shots" ex "mainnet-shots" = "mainnet"
-network: ""
+networkOverride: ""

--- a/snapshotEngine/mainJob.yaml
+++ b/snapshotEngine/mainJob.yaml
@@ -29,7 +29,7 @@ spec:
               trap "exit" SIGINT SIGTERM
 
               # Strip network from namespace or use configmap value
-              NETWORK="${NETWORK:-${NAMESPACE%%-*}}"
+              NETWORK="${NETWORK_OVERRIDE:-${NAMESPACE%%-*}}"
 
               # Set up config for headless RPC using new restored storage
               tezos-node config init \
@@ -154,11 +154,11 @@ spec:
                 configMapKeyRef:
                   name: snapshot-configmap
                   key: NAMESPACE
-            - name: NETWORK
+            - name: NETWORK_OVERRIDE
               valueFrom:
                 configMapKeyRef:
                   name: snapshot-configmap
-                  key: NETWORK
+                  key: NETWORK_OVERRIDE
       containers:
         - name: create-tezos-rolling-snapshot
           image: ""
@@ -173,7 +173,7 @@ spec:
               sudo chown -R 100:100 /rolling-tarball-restore
 
               # Strip network from namespace or use configmap value
-              NETWORK="${NETWORK:-${NAMESPACE%%-*}}"
+              NETWORK="${NETWORK_OVERRIDE:-${NAMESPACE%%-*}}"
 
               BLOCK_HEIGHT=$(cat /"${HISTORY_MODE}"-snapshot-cache-volume/BLOCK_HEIGHT)
               BLOCK_HASH=$(cat /"${HISTORY_MODE}"-snapshot-cache-volume/BLOCK_HASH)
@@ -221,11 +221,11 @@ spec:
                 configMapKeyRef:
                   name: snapshot-configmap
                   key: NAMESPACE
-            - name: NETWORK
+            - name: NETWORK_OVERRIDE
               valueFrom:
                 configMapKeyRef:
                   name: snapshot-configmap
-                  key: NETWORK
+                  key: NETWORK_OVERRIDE
         - name: zip-and-upload
           image: ""
           imagePullPolicy: Always


### PR DESCRIPTION
This fixes an issue where `network` when not set was causing an error.  Tweaked the configmap helm template to fix that. Also renamed from `network` to `networkOverride` to reduce confusion.