### PR TITLE
Snapshot Engine: One metadata for all artifacts

### DIFF
--- a/charts/snapshotEngine/templates/configmap.yaml
+++ b/charts/snapshotEngine/templates/configmap.yaml
@@ -11,7 +11,7 @@ data:
   RESTORED_STORAGE_INIT_TIME: {{ $.Values.restoredStorageInitTime }}
   DISABLE_STORAGE_INIT_TIME: {{ $.Values.disableStorageInitTime | quote }}
   NETWORK_OVERRIDE: {{ $.Values.networkOverride | default "" | quote }}
-  ALL_SUBDOMAINS: {{ .Values.allSubdomains }}
+  ALL_SUBDOMAINS: {{ $.Values.allSubdomains }}
 kind: ConfigMap
 metadata:
   name: snapshot-configmap

--- a/charts/snapshotEngine/templates/configmap.yaml
+++ b/charts/snapshotEngine/templates/configmap.yaml
@@ -11,6 +11,7 @@ data:
   RESTORED_STORAGE_INIT_TIME: {{ $.Values.restoredStorageInitTime }}
   DISABLE_STORAGE_INIT_TIME: {{ $.Values.disableStorageInitTime | quote }}
   NETWORK_OVERRIDE: {{ $.Values.networkOverride | default "" | quote }}
+  ALL_SUBDOMAINS: {{ .Values.allSubdomains }}
 kind: ConfigMap
 metadata:
   name: snapshot-configmap

--- a/charts/snapshotEngine/values.yaml
+++ b/charts/snapshotEngine/values.yaml
@@ -91,3 +91,6 @@ disableStorageInitTime: "false"
 # Can be useful if namespace does not begin with network name.
 # Optional, defaults to beginning word of namespace before "-shots" ex "mainnet-shots" = "mainnet"
 networkOverride: ""
+
+# List of all xtz-shots subdomains
+allSubdomains: ""

--- a/snapshotEngine/Dockerfile
+++ b/snapshotEngine/Dockerfile
@@ -12,7 +12,7 @@ RUN apk --no-cache add \
         binutils \
         curl \
         lz4 \
-        jq  \
+        'jq<1.6-r1'  \
         bash \
     && wget -q -O /usr/bin/yq $(wget -q -O - https://api.github.com/repos/mikefarah/yq/releases/latest \
         | jq -r '.assets[] | select(.name == "yq_linux_amd64") | .browser_download_url') \

--- a/snapshotEngine/Dockerfile
+++ b/snapshotEngine/Dockerfile
@@ -2,8 +2,11 @@ FROM jekyll/jekyll:4.2.0
 
 ENV GLIBC_VER=2.31-r0
 
+# Install python/pip
+ENV PYTHONUNBUFFERED=1
+
 #
-# Installs lz4, jq, yq, kubectl, and awscliv2
+# Installs lz4, jq, yq, kubectl, and awscliv2, and python3
 #
 RUN apk --no-cache add \
         binutils \
@@ -38,7 +41,10 @@ RUN apk --no-cache add \
         glibc-*.apk \
     && apk --no-cache del \
         binutils \
-    && rm -rf /var/cache/apk/*
+    && rm -rf /var/cache/apk/* \
+    && apk add --update --no-cache python3 && ln -sf python3 /usr/bin/python \
+    && python3 -m ensurepip \
+    && pip3 install --no-cache --upgrade pip setuptools boto3
 
 RUN chown jekyll:jekyll -R /usr/gem
 

--- a/snapshotEngine/snapshot-maker.sh
+++ b/snapshotEngine/snapshot-maker.sh
@@ -190,7 +190,8 @@ sleep 5
 while [ "$(kubectl get jobs "zip-and-upload-${HISTORY_MODE}" --namespace "${NAMESPACE}" -o jsonpath='{.status.conditions[?(@.type=="Complete")].status}')" != "True" ]; do
     printf "%s Waiting for zip-and-upload job to complete.\n" "$(date "+%Y-%m-%d %H:%M:%S" "$@")"    
     while [ "$(kubectl get jobs "zip-and-upload-${HISTORY_MODE}" --namespace "${NAMESPACE}" -o jsonpath='{.status.conditions[?(@.type=="Complete")].status}')" != "True" ]; do
-        if kubectl get pod -l job-name=zip-and-upload-"${HISTORY_MODE}" --namespace="${NAMESPACE}"| grep -i -e error -e evicted -e pending; then
+        if [ "$(kubectl get pod -l job-name=zip-and-upload-"${HISTORY_MODE}" --namespace="${NAMESPACE}"| grep -i -e error -e evicted -e pending)" ] || \
+        [ "$(kubectl get jobs  "zip-and-upload-${HISTORY_MODE}" --namespace="${NAMESPACE}" -o jsonpath='{.status.conditions[?(@.type=="Failed")].type}')" ] ; then
             printf "%s Zip-and-upload job failed. This job will end and a new snapshot will be taken.\n" "$(date "+%Y-%m-%d %H:%M:%S" "$@")" 
             break 2
         fi

--- a/snapshotEngine/updateAvailableSnapshotMetadata.py
+++ b/snapshotEngine/updateAvailableSnapshotMetadata.py
@@ -1,0 +1,11 @@
+import os
+import urllib, json
+
+allSubDomains = os.environ('ALL_SUBDOMAINS')
+
+# Iterate over each subDomain/base.json and append to snapshot.json
+
+for subDomain in allSubDomains:
+  url = subDomain+"xtz-shots.io/base.json"
+  response = urllib.urlopen(url)
+  data = json.loads(response.read())

--- a/snapshotEngine/updateAvailableSnapshotMetadata.py
+++ b/snapshotEngine/updateAvailableSnapshotMetadata.py
@@ -1,11 +1,38 @@
+from genericpath import exists
 import os
 import urllib, json
+import urllib.request
+import boto3
+import sys
 
-allSubDomains = os.environ('ALL_SUBDOMAINS')
+allSubDomains = os.environ['ALL_SUBDOMAINS']
 
 # Iterate over each subDomain/base.json and append to snapshot.json
+filename = "snapshots.json"
+with open (filename, "w") as json_file:
+  json.dump("[]",json_file)
 
-for subDomain in allSubDomains:
-  url = subDomain+"xtz-shots.io/base.json"
-  response = urllib.urlopen(url)
-  data = json.loads(response.read())
+if not exists(filename):
+  sys.exit('##### ERROR '+filename+' does not exist! #####')
+
+with open (filename, 'w') as json_file:
+  for subDomain in allSubDomains:
+    # Existing list in snapshots.json
+    existingData = json.load(json_file)
+    # URL to current network metadata file
+    url = "https://"+subDomain+"xtz-shots.io/base.json"
+    # Parse json and turn into list
+    response = urllib.request.urlopen(url)
+    data = json.loads(response.read())
+    # Add new data to new list object
+    existingData.append(data)
+    # Add to snapshots.json
+    json.dump(existingData, json_file)
+
+if not os.path.getsize(filename) > 3:
+  sys.exit('##### ERROR '+filename+' is not greater than 3 bytes! #####')
+
+# Upload to S3 bucket
+s3 = boto3.resource('s3')
+BUCKET = os.environ['S3_BUCKET']
+s3.Bucket(BUCKET).upload_file(filename, filename)

--- a/snapshotEngine/zip-and-upload.sh
+++ b/snapshotEngine/zip-and-upload.sh
@@ -412,13 +412,11 @@ fi
 
 # Build base.json from existing metadata files
 
-printf "##### BEGINNING OF BASE.JSON"
-
 # Create new base.json locally
 touch base.json
 echo '[]' > "base.json"
 
-printf "%s Building base.json... this may take a while." "$(date "+%Y-%m-%d %H:%M:%S" "$@")"
+printf "%s Building base.json... this may take a while.\n" "$(date "+%Y-%m-%d %H:%M:%S" "$@")"
 aws s3 ls s3://"${NETWORK}".xtz-shots.io |  grep '\.json'| sort | awk '{print $4}' | awk -F '\\\\n' '{print $1}' | tr ' ' '\n' | grep -v base.json | while read ITEM; do
     tmp=$(mktemp) && cp base.json "${tmp}" && jq --argjson file "$(curl -s https://"${NETWORK}".xtz-shots.io/$ITEM)" '. += [$file]' "${tmp}" > base.json
 done

--- a/snapshotEngine/zip-and-upload.sh
+++ b/snapshotEngine/zip-and-upload.sh
@@ -440,3 +440,8 @@ if ! aws s3 cp base.json s3://"${S3_BUCKET}"/base.json; then
 else
     printf "%s Upload base.json : File base.json sucessfully uploaded to S3.  \n" "$(date "+%Y-%m-%d %H:%M:%S" "$@")"
 fi
+
+# Create snapshot.json
+# List of all snapshot metadata accross all subdomains
+
+python updateAvailableSnapshotMetadata.py

--- a/snapshotEngine/zip-and-upload.sh
+++ b/snapshotEngine/zip-and-upload.sh
@@ -5,8 +5,7 @@ BLOCK_HASH=$(cat /"${HISTORY_MODE}"-snapshot-cache-volume/BLOCK_HASH)
 BLOCK_TIMESTAMP=$(cat /"${HISTORY_MODE}"-snapshot-cache-volume/BLOCK_TIMESTAMP)
 TEZOS_VERSION=$(cat /"${HISTORY_MODE}"-snapshot-cache-volume/TEZOS_VERSION)
 NETWORK="${NAMESPACE%%-*}"
-
-S3_BUCKET="${NETWORK}.${SNAPSHOT_WEBSITE_DOMAIN_NAME}"
+export S3_BUCKET="${NETWORK}.${SNAPSHOT_WEBSITE_DOMAIN_NAME}"
 
 cd /
 
@@ -424,16 +423,6 @@ aws s3 ls s3://"${NETWORK}".xtz-shots.io |  grep '\.json'| sort | awk '{print $4
     tmp=$(mktemp) && cp base.json "${tmp}" && jq --argjson file "$(curl -s https://"${NETWORK}".xtz-shots.io/$ITEM)" '. += [$file]' "${tmp}" > base.json
 done
 
-# DEBUG
-
-printf "%s" "$(cat base.json || true)"
-printf "##### END OF BASE.JSON"
-# END DEBUG
-
-# aws s3 ls s3://$NETWORK.xtz-shots.io |  grep '\.json'| sort | awk '{print $4}' | awk -F '\\\\n' '{print $1}' | tr ' ' '\n' | grep -v base.json | while read ITEM; do
-#     echo $ITEM
-# done
-
 #Upload base.json
 if ! aws s3 cp base.json s3://"${S3_BUCKET}"/base.json; then
     printf "%s Upload base.json : Error uploading file base.json to S3.  \n" "$(date "+%Y-%m-%d %H:%M:%S" "$@")"
@@ -444,4 +433,4 @@ fi
 # Create snapshot.json
 # List of all snapshot metadata accross all subdomains
 
-python updateAvailableSnapshotMetadata.py
+python /updateAvailableSnapshotMetadata.py

--- a/snapshotEngine/zip-and-upload.sh
+++ b/snapshotEngine/zip-and-upload.sh
@@ -417,7 +417,7 @@ touch base.json
 echo '[]' > "base.json"
 
 printf "%s Building base.json... this may take a while.\n" "$(date "+%Y-%m-%d %H:%M:%S" "$@")"
-aws s3 ls s3://"${NETWORK}".xtz-shots.io |  grep '\.json'| sort | awk '{print $4}' | awk -F '\\\\n' '{print $1}' | tr ' ' '\n' | grep -v base.json | while read ITEM; do
+aws s3 ls s3://"${NETWORK}".xtz-shots.io |  grep '\.json'| sort | awk '{print $4}' | awk -F '\\\\n' '{print $1}' | tr ' ' '\n' | grep -v -e base.json -e snapshots.json | while read ITEM; do
     tmp=$(mktemp) && cp base.json "${tmp}" && jq --argjson file "$(curl -s https://"${NETWORK}".xtz-shots.io/$ITEM)" '. += [$file]' "${tmp}" > base.json
 done
 


### PR DESCRIPTION
Fixes https://github.com/oxheadalpha/tezos-k8s/issues/446

This PR provides all subdomains on xtz-shots to the zip-and-upload-job where they are fed into a python script that constructs a list of all current artifacts across all networks and provides it at `xtz-shots.io/snapshots.json`.

TODO:

- [ ] Right now `snapshots.json` is served at `subdomain.xtz-shots.io/snapshots.json` so every subdomain has the same `snapshots.json`, this needs to be moved up to `xtz-shots.io/snapshots.json`.