### PR TITLE
podman compat in development mode

### DIFF
--- a/charts/tezos/values.yaml
+++ b/charts/tezos/values.yaml
@@ -12,8 +12,8 @@ images:
   tezedge: tezedge/tezedge:v1.6.8
 # Images that are part of the tezos-k8s repo go here with 'dev' tag
 tezos_k8s_images:
-  utils: tezos-k8s-utils:dev
-  zerotier: tezos-k8s-zerotier:dev
+  utils: localhost/tezos-k8s-utils:dev
+  zerotier: localhost/tezos-k8s-zerotier:dev
 
 ## Properties that are templated for some k8s resources. There are container
 ## scripts that will look up some of these values. They should not be modified.

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -9,15 +9,15 @@ deployments:
 
 images:
   zerotier:
-    image: tezos-k8s-zerotier
+    image: localhost/tezos-k8s-zerotier
     dockerfile: ./zerotier/Dockerfile
     context: ./zerotier
   utils:
-    image: tezos-k8s-utils
+    image: localhost/tezos-k8s-utils
     dockerfile: ./utils/Dockerfile
     context: ./utils
   faucet:
-    image: tezos-k8s-faucet
+    image: localhost/tezos-k8s-faucet
     dockerfile: ./faucet/Dockerfile
     context: ./faucet
 

--- a/test/charts/mainnet.expect.yaml
+++ b/test/charts/mainnet.expect.yaml
@@ -158,7 +158,7 @@ spec:
               path: /is_synced
               port: 31732                                                        
         - name: sidecar
-          image: "tezos-k8s-utils:dev"
+          image: "localhost/tezos-k8s-utils:dev"
           imagePullPolicy: IfNotPresent
           args:
             - sidecar
@@ -233,7 +233,7 @@ spec:
             - mountPath: /var/tezos
               name: var-volume                
         - name: config-generator
-          image: "tezos-k8s-utils:dev"
+          image: "localhost/tezos-k8s-utils:dev"
           imagePullPolicy: IfNotPresent
           args:
             - config-generator
@@ -263,7 +263,7 @@ spec:
             - mountPath: /etc/secret-volume
               name: tezos-accounts        
         - name: snapshot-downloader
-          image: "tezos-k8s-utils:dev"
+          image: "localhost/tezos-k8s-utils:dev"
           imagePullPolicy: IfNotPresent
           args:
             - snapshot-downloader

--- a/test/charts/mainnet2.expect.yaml
+++ b/test/charts/mainnet2.expect.yaml
@@ -189,7 +189,7 @@ spec:
               path: /is_synced
               port: 31732                        
         - name: logger
-          image: "tezos-k8s-utils:dev"
+          image: "localhost/tezos-k8s-utils:dev"
           imagePullPolicy: IfNotPresent
           args:
             - logger
@@ -253,7 +253,7 @@ spec:
             - name: DAEMON
               value: tezos-metrics                
         - name: sidecar
-          image: "tezos-k8s-utils:dev"
+          image: "localhost/tezos-k8s-utils:dev"
           imagePullPolicy: IfNotPresent
           args:
             - sidecar
@@ -332,7 +332,7 @@ spec:
             - mountPath: /var/tezos
               name: var-volume                
         - name: config-generator
-          image: "tezos-k8s-utils:dev"
+          image: "localhost/tezos-k8s-utils:dev"
           imagePullPolicy: IfNotPresent
           args:
             - config-generator
@@ -364,7 +364,7 @@ spec:
             - mountPath: /etc/secret-volume
               name: tezos-accounts        
         - name: snapshot-downloader
-          image: "tezos-k8s-utils:dev"
+          image: "localhost/tezos-k8s-utils:dev"
           imagePullPolicy: IfNotPresent
           args:
             - snapshot-downloader
@@ -546,7 +546,7 @@ spec:
               path: /is_synced
               port: 31732                                
         - name: logger
-          image: "tezos-k8s-utils:dev"
+          image: "localhost/tezos-k8s-utils:dev"
           imagePullPolicy: IfNotPresent
           args:
             - logger
@@ -610,7 +610,7 @@ spec:
             - name: DAEMON
               value: tezos-metrics                
         - name: sidecar
-          image: "tezos-k8s-utils:dev"
+          image: "localhost/tezos-k8s-utils:dev"
           imagePullPolicy: IfNotPresent
           args:
             - sidecar
@@ -689,7 +689,7 @@ spec:
             - mountPath: /var/tezos
               name: var-volume                
         - name: config-generator
-          image: "tezos-k8s-utils:dev"
+          image: "localhost/tezos-k8s-utils:dev"
           imagePullPolicy: IfNotPresent
           args:
             - config-generator
@@ -721,7 +721,7 @@ spec:
             - mountPath: /etc/secret-volume
               name: tezos-accounts        
         - name: snapshot-downloader
-          image: "tezos-k8s-utils:dev"
+          image: "localhost/tezos-k8s-utils:dev"
           imagePullPolicy: IfNotPresent
           args:
             - snapshot-downloader

--- a/test/charts/private-chain.expect.yaml
+++ b/test/charts/private-chain.expect.yaml
@@ -363,7 +363,7 @@ spec:
             - mountPath: /var/tezos
               name: var-volume        
         - name: logger
-          image: "tezos-k8s-utils:dev"
+          image: "localhost/tezos-k8s-utils:dev"
           imagePullPolicy: IfNotPresent
           args:
             - logger
@@ -425,7 +425,7 @@ spec:
             - name: DAEMON
               value: tezos-metrics                
         - name: sidecar
-          image: "tezos-k8s-utils:dev"
+          image: "localhost/tezos-k8s-utils:dev"
           imagePullPolicy: IfNotPresent
           args:
             - sidecar
@@ -454,7 +454,7 @@ spec:
               name: var-volume        
       initContainers:                        
         - name: config-generator
-          image: "tezos-k8s-utils:dev"
+          image: "localhost/tezos-k8s-utils:dev"
           imagePullPolicy: IfNotPresent
           args:
             - config-generator
@@ -484,7 +484,7 @@ spec:
             - mountPath: /etc/secret-volume
               name: tezos-accounts                        
         - name: wait-for-dns
-          image: "tezos-k8s-utils:dev"
+          image: "localhost/tezos-k8s-utils:dev"
           imagePullPolicy: IfNotPresent
           args:
             - wait-for-dns
@@ -591,7 +591,7 @@ spec:
               path: /is_synced
               port: 31732                                                        
         - name: sidecar
-          image: "tezos-k8s-utils:dev"
+          image: "localhost/tezos-k8s-utils:dev"
           imagePullPolicy: IfNotPresent
           args:
             - sidecar
@@ -620,7 +620,7 @@ spec:
               name: var-volume        
       initContainers:                        
         - name: config-generator
-          image: "tezos-k8s-utils:dev"
+          image: "localhost/tezos-k8s-utils:dev"
           imagePullPolicy: IfNotPresent
           args:
             - config-generator
@@ -650,7 +650,7 @@ spec:
             - mountPath: /etc/secret-volume
               name: tezos-accounts                        
         - name: wait-for-dns
-          image: "tezos-k8s-utils:dev"
+          image: "localhost/tezos-k8s-utils:dev"
           imagePullPolicy: IfNotPresent
           args:
             - wait-for-dns
@@ -809,7 +809,7 @@ spec:
             - mountPath: /var/tezos
               name: var-volume        
         - name: logger
-          image: "tezos-k8s-utils:dev"
+          image: "localhost/tezos-k8s-utils:dev"
           imagePullPolicy: IfNotPresent
           args:
             - logger
@@ -871,7 +871,7 @@ spec:
             - name: DAEMON
               value: tezos-metrics                
         - name: sidecar
-          image: "tezos-k8s-utils:dev"
+          image: "localhost/tezos-k8s-utils:dev"
           imagePullPolicy: IfNotPresent
           args:
             - sidecar
@@ -900,7 +900,7 @@ spec:
               name: var-volume        
       initContainers:                        
         - name: config-generator
-          image: "tezos-k8s-utils:dev"
+          image: "localhost/tezos-k8s-utils:dev"
           imagePullPolicy: IfNotPresent
           args:
             - config-generator
@@ -930,7 +930,7 @@ spec:
             - mountPath: /etc/secret-volume
               name: tezos-accounts                        
         - name: wait-for-dns
-          image: "tezos-k8s-utils:dev"
+          image: "localhost/tezos-k8s-utils:dev"
           imagePullPolicy: IfNotPresent
           args:
             - wait-for-dns
@@ -1088,7 +1088,7 @@ spec:
             - mountPath: /var/tezos
               name: var-volume                                
         - name: sidecar
-          image: "tezos-k8s-utils:dev"
+          image: "localhost/tezos-k8s-utils:dev"
           imagePullPolicy: IfNotPresent
           args:
             - sidecar
@@ -1117,7 +1117,7 @@ spec:
               name: var-volume        
       initContainers:                        
         - name: config-generator
-          image: "tezos-k8s-utils:dev"
+          image: "localhost/tezos-k8s-utils:dev"
           imagePullPolicy: IfNotPresent
           args:
             - config-generator
@@ -1147,7 +1147,7 @@ spec:
             - mountPath: /etc/secret-volume
               name: tezos-accounts                        
         - name: wait-for-dns
-          image: "tezos-k8s-utils:dev"
+          image: "localhost/tezos-k8s-utils:dev"
           imagePullPolicy: IfNotPresent
           args:
             - wait-for-dns
@@ -1233,7 +1233,7 @@ spec:
             exec $CMD
             
       initContainers:
-      - image: tezos-k8s-utils:dev
+      - image: localhost/tezos-k8s-utils:dev
         imagePullPolicy: IfNotPresent
         name: config-generator
         args:
@@ -1313,7 +1313,7 @@ spec:
             - mountPath: /var/tezos
               name: var-volume
       initContainers:
-        - image: tezos-k8s-utils:dev
+        - image: localhost/tezos-k8s-utils:dev
           imagePullPolicy: IfNotPresent
           name: config-generator
           args:


### PR DESCRIPTION
Podman does not accept docker image tags in the format image:tag as
local, it requires `localhost/` when the image was built locally.

This small change saves me time because a `mkchain` default yaml works
on my machine again.

I believe this will not break the development workflow for docker users,
please confirm.