### PR TITLE
Pyrometer: put ingress in chart

### DIFF
--- a/charts/pyrometer/templates/_helpers.tpl
+++ b/charts/pyrometer/templates/_helpers.tpl
@@ -6,24 +6,6 @@ Expand the name of the chart.
 {{- end }}
 
 {{/*
-Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If release name contains chart name it will be used as a full name.
-*/}}
-{{- define "pyrometer.fullname" -}}
-{{- if .Values.fullnameOverride }}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
-{{- if contains $name .Release.Name }}
-{{- .Release.Name | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
-{{- end }}
-{{- end }}
-{{- end }}
-
-{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "pyrometer.chart" -}}
@@ -48,15 +30,4 @@ Selector labels
 {{- define "pyrometer.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "pyrometer.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
-{{- end }}
-
-{{/*
-Create the name of the service account to use
-*/}}
-{{- define "pyrometer.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
-{{- default (include "pyrometer.fullname" .) .Values.serviceAccount.name }}
-{{- else }}
-{{- default "default" .Values.serviceAccount.name }}
-{{- end }}
 {{- end }}

--- a/charts/pyrometer/templates/_helpers.tpl
+++ b/charts/pyrometer/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "pyrometer.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "pyrometer.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "pyrometer.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "pyrometer.labels" -}}
+helm.sh/chart: {{ include "pyrometer.chart" . }}
+{{ include "pyrometer.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "pyrometer.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "pyrometer.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "pyrometer.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "pyrometer.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/pyrometer/templates/ingress.yaml
+++ b/charts/pyrometer/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled -}}
-{{- $fullName := include "pyrometer.fullname" . -}}
+{{- $fullName := "pyrometer" -}}
 {{- $svcPort := .Values.service.port -}}
 {{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
   {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}

--- a/charts/pyrometer/templates/ingress.yaml
+++ b/charts/pyrometer/templates/ingress.yaml
@@ -37,25 +37,11 @@ spec:
     {{- end }}
   {{- end }}
   rules:
-    {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
-      http:
-        paths:
-          {{- range .paths }}
-          - path: {{ .path }}
-            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
-            pathType: {{ .pathType }}
-            {{- end }}
-            backend:
-              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
-              service:
-                name: {{ $fullName }}
-                port:
-                  number: {{ $svcPort }}
-              {{- else }}
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
-              {{- end }}
-          {{- end }}
-    {{- end }}
+    - host: {{ .Values.ingress.host | quote }}
+      paths:
+        - path: /
+          pathType: Prefix
+          backend:
+            serviceName: "pyrometer"
+            portName: "http"
 {{- end }}

--- a/charts/pyrometer/templates/ingress.yaml
+++ b/charts/pyrometer/templates/ingress.yaml
@@ -1,6 +1,5 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := "pyrometer" -}}
-{{- $svcPort := .Values.service.port -}}
 {{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
   {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
   {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}

--- a/charts/pyrometer/templates/ingress.yaml
+++ b/charts/pyrometer/templates/ingress.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "pyrometer.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "pyrometer.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/pyrometer/templates/ingress.yaml
+++ b/charts/pyrometer/templates/ingress.yaml
@@ -37,10 +37,11 @@ spec:
   {{- end }}
   rules:
     - host: {{ .Values.ingress.host | quote }}
-      paths:
-        - path: /
-          pathType: Prefix
-          backend:
-            serviceName: "pyrometer"
-            portName: "http"
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              serviceName: "pyrometer"
+              portName: "http"
 {{- end }}

--- a/charts/pyrometer/values.yaml
+++ b/charts/pyrometer/values.yaml
@@ -2,6 +2,9 @@
 config: {}
 images:
   pyrometer: registry.gitlab.com/tezos-kiln/pyrometer:latest
+service:
+  type: ClusterIP
+  port: 80
 ingress:
   enabled: false
   className: ""

--- a/charts/pyrometer/values.yaml
+++ b/charts/pyrometer/values.yaml
@@ -11,14 +11,7 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
-  hosts:
-    - host: chart-example.local
-      paths:
-        - path: /
-          pathType: Prefix
-          backend:
-            serviceName: "pyrometer"
-            portName: 'http'
+  host: chart-example.local
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:

--- a/charts/pyrometer/values.yaml
+++ b/charts/pyrometer/values.yaml
@@ -2,9 +2,6 @@
 config: {}
 images:
   pyrometer: registry.gitlab.com/tezos-kiln/pyrometer:latest
-service:
-  type: ClusterIP
-  port: 80
 ingress:
   enabled: false
   className: ""

--- a/charts/pyrometer/values.yaml
+++ b/charts/pyrometer/values.yaml
@@ -15,7 +15,10 @@ ingress:
     - host: chart-example.local
       paths:
         - path: /
-          pathType: ImplementationSpecific
+          pathType: Prefix
+          backend:
+            serviceName: "pyrometer"
+            portName: 'http'
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:

--- a/charts/pyrometer/values.yaml
+++ b/charts/pyrometer/values.yaml
@@ -11,7 +11,7 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
-  host: chart-example.local
+  host: "" # fill in the desired hostname for your ingress
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:

--- a/charts/pyrometer/values.yaml
+++ b/charts/pyrometer/values.yaml
@@ -2,3 +2,18 @@
 config: {}
 images:
   pyrometer: registry.gitlab.com/tezos-kiln/pyrometer:latest
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local


### PR DESCRIPTION
Since the beginning of tezos-k8s we have always deployed ingresses
outside of our charts.

Is it the right approach? Maybe not: the default helm chart created with
`helm init` has a pre-configured ingress template file.

This ingress template file is sufficient for our use cases: we can pass
ingress annotations and TLS configuration with values.yaml.

Therefore, we add an option to define the ingress with helm directly.
This allows to remove an ingress definition from the teztnets and
oxheadinfra code bases, simplifying it.

We should consider doing that for Tezos RPC as well.