### PR TITLE
fix wrong syntax in pyrometer ingress

### DIFF
--- a/charts/pyrometer/templates/ingress.yaml
+++ b/charts/pyrometer/templates/ingress.yaml
@@ -42,6 +42,8 @@ spec:
           - path: /
             pathType: Prefix
             backend:
-              serviceName: "pyrometer"
-              portName: "http"
+              service:
+                name: "pyrometer"
+                port:
+                  number: 80
 {{- end }}


### PR DESCRIPTION
after last-minute PR fix, it broke. This branch is now running on teztnets, so it works for sure.