### PR TITLE
export all artifacts in jekyll metadata

### DIFF
--- a/snapshotEngine/getLatestSnapshotMetadata.py
+++ b/snapshotEngine/getLatestSnapshotMetadata.py
@@ -20,6 +20,8 @@ snapshots_per_network = {}
 #   Error reading file /home/nochem/workspace/xtz-shots-website/_layouts/latest_snapshots.md/latest_snapshots.md: Not a directory @ rb_sysopen - /home/nochem/workspace/xtz-shots-website/_layouts/latest_snapshots.md/latest_snapshots.md
 latest_snapshots = [{ "name": "example", "latest_snapshots" : {}}]
 
+all_snapshots = [{ "name": "example", "all_snapshots" : {}}]
+
 for snapshot in snapshots:
     network = snapshot["chain_name"]
     if network not in snapshots_per_network:
@@ -28,16 +30,20 @@ for snapshot in snapshots:
 
 for network, snapshots in snapshots_per_network.items():
     network_latest_snapshots = {}
+    network_snapshots = {}
     for (type, mode, path) in [("tarball", "rolling", "rolling-tarball"), ("tarball", "archive", "archive-tarball"), ("tezos-snapshot", "rolling", "rolling")]:
         typed_snapshots = [s for s in snapshots if s["artifact_type"] == type and s["history_mode"] == mode]
         typed_snapshots.sort(key=lambda x: int(x["block_height"]), reverse=True)
         try:
             network_latest_snapshots[path] = typed_snapshots[0]
+            network_snapshots[path] = typed_snapshots
         except IndexError:
             continue
     latest_snapshots.append(
         { "name": network, "permalink": network+"/index.html", "latest_snapshots": network_latest_snapshots })
+    all_snapshots.append(
+        { "name": network, "permalink": network+"/list.html", "snapshots": network_snapshots })
 
 Path("_data").mkdir(parents=True, exist_ok=True)
 with open(f"_data/snapshot_jekyll_data.json", 'w') as f:
-    json.dump({"latest_snapshots": latest_snapshots}, f, indent=2)
+    json.dump({"latest_snapshots": latest_snapshots, "all_snapshots": all_snapshots}, f, indent=2)


### PR DESCRIPTION

![Screenshot from 2022-09-03 11-12-48](https://user-images.githubusercontent.com/93067/188283245-cd00a213-efcc-40e9-8ca6-e7530b0fbcfe.png)
![Screenshot from 2022-09-03 11-12-31](https://user-images.githubusercontent.com/93067/188283249-44b81319-4a19-4c36-8987-e31c7e3e73b2.png)
This allows for the creation of a file explorer.

A basic file explorer can be deployed by merging the PR:

https://github.com/oxheadalpha/xtz-shots-website/pull/14

Before this goes to mainnet, this file should probably be renamed from
`getLtestSnapshotMetadata.py` to `generateJekyllData.py` since it's no
longer only about latest artifacts.

When we have v13 and v14 namespaces, the v13 and v14 artifacts will
seamlessly be mixed together in the same file explorer page. This is as
desired.

After we deploy the file explorer and v13/v14 artifacts, let's send this
tweet:

> Tezos Kathmandu protocol will activate on <date>. You must upgrade your
node to Octez v14.
> Upgrading your node requires a storage migration step. To make
migration easier for you, snapshots and tarballs for both v13 and v14
are now available on XTZ-Shots.io
> You can easily browse all available artifacts with our new file
explorer:

Attach a small video of the front page and file explorer navigation flow
to the tweet.