### PR TITLE
Tezos: New init container to upgrade storage

### DIFF
--- a/charts/tezos/scripts/upgrade-storage.sh
+++ b/charts/tezos/scripts/upgrade-storage.sh
@@ -1,0 +1,3 @@
+set -ex
+
+tezos-node upgrade storage --data-dir /var/tezos/node/data

--- a/charts/tezos/templates/_containers.tpl
+++ b/charts/tezos/templates/_containers.tpl
@@ -229,6 +229,15 @@
   {{- end }}
 {{- end }}
 
+{{- define "tezos.init_container.upgrade_storage" }}
+    {{- include "tezos.generic_container" (dict "root"   $
+                                           "type"        "upgrade-storage"
+                                           "image"       "octez"
+                                           "with_config" 1
+                                           "localvars"   1
+    )  | nindent 0 }}
+{{- end }}
+
 {{- define "tezos.container.sidecar" }}
   {{- if or (not (hasKey $.node_vals "readiness_probe")) $.node_vals.readiness_probe }}
     {{- include "tezos.generic_container" (dict "root"  $

--- a/charts/tezos/templates/nodes.yaml
+++ b/charts/tezos/templates/nodes.yaml
@@ -47,6 +47,7 @@ spec:
         {{- include "tezos.init_container.snapshot_downloader" $ | indent 8 }}
         {{- include "tezos.init_container.snapshot_importer"   $ | indent 8 }}
         {{- include "tezos.init_container.wait_for_dns"        $ | indent 8 }}
+        {{- include "tezos.init_container.upgrade_storage"     $ | indent 8 }}
       securityContext:
         fsGroup: 100
 {{- include "tezos.nodeSelectorConfig" $ | indent 6 }}

--- a/test/charts/mainnet.expect.yaml
+++ b/test/charts/mainnet.expect.yaml
@@ -344,7 +344,41 @@ spec:
             - mountPath: /etc/tezos
               name: config-volume
             - mountPath: /var/tezos
-              name: var-volume        
+              name: var-volume                
+        - name: upgrade-storage
+          image: "tezos/tezos:v14-release"
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+          args:
+            - "-c"
+            - |
+              set -ex
+              
+              tezos-node upgrade storage --data-dir /var/tezos/node/data
+          envFrom:
+            - configMapRef:
+                name: tezos-config
+          env:    
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MY_POD_TYPE
+              value: node
+            - name: MY_NODE_CLASS
+              value: rolling-node
+            - name: DAEMON
+              value: upgrade-storage
+          volumeMounts:
+            - mountPath: /etc/tezos
+              name: config-volume
+            - mountPath: /var/tezos
+              name: var-volume
       securityContext:
         fsGroup: 100      
       volumes:

--- a/test/charts/mainnet2.expect.yaml
+++ b/test/charts/mainnet2.expect.yaml
@@ -449,7 +449,43 @@ spec:
             - mountPath: /etc/tezos
               name: config-volume
             - mountPath: /var/tezos
-              name: var-volume        
+              name: var-volume                
+        - name: upgrade-storage
+          image: "tezos/tezos:v14-release"
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+          args:
+            - "-c"
+            - |
+              set -ex
+              
+              tezos-node upgrade storage --data-dir /var/tezos/node/data
+          envFrom:
+            - configMapRef:
+                name: tezos-config
+          env:    
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MY_POD_TYPE
+              value: node
+            - name: MY_NODE_CLASS
+              value: city-block
+            - name: DAEMON
+              value: upgrade-storage
+            - name:  key
+              value: "outer-value"
+          volumeMounts:
+            - mountPath: /etc/tezos
+              name: config-volume
+            - mountPath: /var/tezos
+              name: var-volume
       securityContext:
         fsGroup: 100      
       volumes:
@@ -806,7 +842,43 @@ spec:
             - mountPath: /etc/tezos
               name: config-volume
             - mountPath: /var/tezos
-              name: var-volume        
+              name: var-volume                
+        - name: upgrade-storage
+          image: "tezos/tezos:v14-release"
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+          args:
+            - "-c"
+            - |
+              set -ex
+              
+              tezos-node upgrade storage --data-dir /var/tezos/node/data
+          envFrom:
+            - configMapRef:
+                name: tezos-config
+          env:    
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MY_POD_TYPE
+              value: node
+            - name: MY_NODE_CLASS
+              value: country-town
+            - name: DAEMON
+              value: upgrade-storage
+            - name:  key
+              value: "specific-pod"
+          volumeMounts:
+            - mountPath: /etc/tezos
+              name: config-volume
+            - mountPath: /var/tezos
+              name: var-volume
       securityContext:
         fsGroup: 100      
       volumes:

--- a/test/charts/private-chain.expect.yaml
+++ b/test/charts/private-chain.expect.yaml
@@ -520,6 +520,40 @@ spec:
             - mountPath: /etc/tezos
               name: config-volume
             - mountPath: /var/tezos
+              name: var-volume        
+        - name: upgrade-storage
+          image: "tezos/tezos:v14-release"
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+          args:
+            - "-c"
+            - |
+              set -ex
+              
+              tezos-node upgrade storage --data-dir /var/tezos/node/data
+          envFrom:
+            - configMapRef:
+                name: tezos-config
+          env:    
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MY_POD_TYPE
+              value: node
+            - name: MY_NODE_CLASS
+              value: af
+            - name: DAEMON
+              value: upgrade-storage
+          volumeMounts:
+            - mountPath: /etc/tezos
+              name: config-volume
+            - mountPath: /var/tezos
               name: var-volume
       securityContext:
         fsGroup: 100      
@@ -685,6 +719,40 @@ spec:
           env:
             - name: DAEMON
               value: wait-for-dns
+          volumeMounts:
+            - mountPath: /etc/tezos
+              name: config-volume
+            - mountPath: /var/tezos
+              name: var-volume        
+        - name: upgrade-storage
+          image: "tezos/tezos:v14-release"
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+          args:
+            - "-c"
+            - |
+              set -ex
+              
+              tezos-node upgrade storage --data-dir /var/tezos/node/data
+          envFrom:
+            - configMapRef:
+                name: tezos-config
+          env:    
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MY_POD_TYPE
+              value: node
+            - name: MY_NODE_CLASS
+              value: as
+            - name: DAEMON
+              value: upgrade-storage
           volumeMounts:
             - mountPath: /etc/tezos
               name: config-volume
@@ -985,6 +1053,40 @@ spec:
             - mountPath: /etc/tezos
               name: config-volume
             - mountPath: /var/tezos
+              name: var-volume        
+        - name: upgrade-storage
+          image: "tezos/tezos:v14-release"
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+          args:
+            - "-c"
+            - |
+              set -ex
+              
+              tezos-node upgrade storage --data-dir /var/tezos/node/data
+          envFrom:
+            - configMapRef:
+                name: tezos-config
+          env:    
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MY_POD_TYPE
+              value: node
+            - name: MY_NODE_CLASS
+              value: eu
+            - name: DAEMON
+              value: upgrade-storage
+          volumeMounts:
+            - mountPath: /etc/tezos
+              name: config-volume
+            - mountPath: /var/tezos
               name: var-volume
       securityContext:
         fsGroup: 100      
@@ -1214,6 +1316,40 @@ spec:
           env:
             - name: DAEMON
               value: wait-for-dns
+          volumeMounts:
+            - mountPath: /etc/tezos
+              name: config-volume
+            - mountPath: /var/tezos
+              name: var-volume        
+        - name: upgrade-storage
+          image: "tezos/tezos:v14-release"
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+          args:
+            - "-c"
+            - |
+              set -ex
+              
+              tezos-node upgrade storage --data-dir /var/tezos/node/data
+          envFrom:
+            - configMapRef:
+                name: tezos-config
+          env:    
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MY_POD_TYPE
+              value: node
+            - name: MY_NODE_CLASS
+              value: us
+            - name: DAEMON
+              value: upgrade-storage
           volumeMounts:
             - mountPath: /etc/tezos
               name: config-volume


### PR DESCRIPTION
This PR adds an init container that runs `tezos-node upgrade storage --data-dir /var/tezos/node/data`.

This is being done ahead of kathmandu activation.

Tested with a ghostnet v13 node, then upgraded to v14.
```bash
│ + tezos-node upgrade storage --data-dir /var/tezos/node/data                                                                                                                      │
│ Sep  9 18:52:20.731 - node_data_version: upgrading data directory from 0.8 to 1.0                                                                                                 │
│ Sep  9 18:52:20.821 - node_data_version: the node data dir is now up-to-date
```

If no upgrade is needed the container finishes very quickly with
```bash
│ + tezos-node upgrade storage --data-dir /var/tezos/node/data                                                                                                                      │
│ Sep  9 19:08:02.508 - node_data_version: node data dir is up-to-date
```
