### PR TITLE
SnapshotEngine: Check for stuck snapshots and delete

### DIFF
--- a/charts/snapshotEngine/scripts/snapshot-warmer.sh
+++ b/charts/snapshotEngine/scripts/snapshot-warmer.sh
@@ -37,6 +37,32 @@ delete_old_volumesnapshots() {
   done
 }
 
+delete_stuck_volumesnapshots() {
+  snapshot_list=$(kubectl get volumesnapshots -o jsonpath="{.items[*].metadata.name}")
+  arr=(`echo ${snapshot_list}`);
+  for snapshot_name in "${arr[@]}"; do
+    snapshot_creation_time_iso8601=$(kubectl get volumesnapshots $snapshot_name -o jsonpath='{.metadata.creationTimestamp}')
+    snapshot_creation_time_without_offset=${snapshot_creation_time_iso8601::-1}
+    snapshot_creation_time_unix=$(date -ud "$(echo $snapshot_creation_time_without_offset | sed 's/T/ /')" +%s)
+    current_date_unix=$(date -u +%s)
+    snapshot_age_minutes=$(( (current_date_unix - snapshot_creation_time_unix) / 60  ))
+    # Snapshots should never be older than 6 minutes
+    # If they are then there's a problem on AWS' end and the snapshot needs to be deleted.
+    if [ $snapshot_age_minutes -ge 6 ]; then
+      printf "%s Snasphot %s is %s minutes old.  It must be stuck. Attempting to delete...\n" "$(timestamp)" "$snapshot_name" "$snapshot_age_minutes"
+      err=$(kubectl delete volumesnapshots $snapshot_name 2>&1 > /dev/null)
+      if [ $? -ne 0 ]; then
+        printf "%s ERROR##### Unable to delete stuck snapshot %s .\n" "$(timestamp)" "$snapshot_name"
+        printf "%s Error was: \"%s\"\n" "$(timestamp)" "$err"
+        sleep 10
+        exit 1
+      else
+         printf "%s Sucessfully deleted stuck snapshot %s! \n" "$(timestamp)" "$snapshot_name"
+      fi
+    fi
+  done
+}
+
 HISTORY_MODE="$(echo "$NODE_CONFIG" | jq -r ".history_mode")"
 TARGET_VOLUME="$(echo "$NODE_CONFIG" | jq ".target_volume")"
 PERSISTENT_VOLUME_CLAIM="$(
@@ -61,6 +87,8 @@ while true; do
   delete_old_volumesnapshots selector='!history_mode' max_snapshots=0
   # Maintain 4 snapshots of a certain history mode
   delete_old_volumesnapshots selector="history_mode=$HISTORY_MODE" max_snapshots=4
+  # Check for and delete old stuck snapshots
+  delete_stuck_volumesnapshots
 
   if ! [ "$(getSnapshotNames readyToUse=false -l history_mode="${HISTORY_MODE}")" ]; then
     # EBS Snapshot name based on current time and date
@@ -85,7 +113,7 @@ while true; do
     while [ "$(getSnapshotNames readyToUse=false -l history_mode="${HISTORY_MODE}")" ]; do
       printf "%s Snapshot is still creating...\n" "$(timestamp)"
       sleep 10
-
+      delete_stuck_volumesnapshots
     done
     end_time=$(date +%s)
     elapsed=$((end_time - start_time))
@@ -94,5 +122,12 @@ while true; do
   else
     printf "%s Snapshot already in progress...\n" "$(timestamp)"
     sleep 10
+    delete_stuck_volumesnapshots
   fi
 done
+
+if kubectl get asdfasf > /dev/null 2>&1; then
+  echo "Success!"
+else
+  echo "Failure!"
+fi

--- a/charts/tezos/scripts/upgrade-storage.sh
+++ b/charts/tezos/scripts/upgrade-storage.sh
@@ -1,0 +1,3 @@
+set -ex
+
+tezos-node upgrade storage --data-dir /var/tezos/node/data

--- a/charts/tezos/templates/_containers.tpl
+++ b/charts/tezos/templates/_containers.tpl
@@ -229,6 +229,15 @@
   {{- end }}
 {{- end }}
 
+{{- define "tezos.init_container.upgrade_storage" }}
+    {{- include "tezos.generic_container" (dict "root"   $
+                                           "type"        "upgrade-storage"
+                                           "image"       "octez"
+                                           "with_config" 1
+                                           "localvars"   1
+    )  | nindent 0 }}
+{{- end }}
+
 {{- define "tezos.container.sidecar" }}
   {{- if or (not (hasKey $.node_vals "readiness_probe")) $.node_vals.readiness_probe }}
     {{- include "tezos.generic_container" (dict "root"  $

--- a/charts/tezos/templates/nodes.yaml
+++ b/charts/tezos/templates/nodes.yaml
@@ -47,6 +47,7 @@ spec:
         {{- include "tezos.init_container.snapshot_downloader" $ | indent 8 }}
         {{- include "tezos.init_container.snapshot_importer"   $ | indent 8 }}
         {{- include "tezos.init_container.wait_for_dns"        $ | indent 8 }}
+        {{- include "tezos.init_container.upgrade_storage"     $ | indent 8 }}
       securityContext:
         fsGroup: 100
 {{- include "tezos.nodeSelectorConfig" $ | indent 6 }}

--- a/test/charts/mainnet.expect.yaml
+++ b/test/charts/mainnet.expect.yaml
@@ -344,7 +344,41 @@ spec:
             - mountPath: /etc/tezos
               name: config-volume
             - mountPath: /var/tezos
-              name: var-volume        
+              name: var-volume                
+        - name: upgrade-storage
+          image: "tezos/tezos:v14-release"
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+          args:
+            - "-c"
+            - |
+              set -ex
+              
+              tezos-node upgrade storage --data-dir /var/tezos/node/data
+          envFrom:
+            - configMapRef:
+                name: tezos-config
+          env:    
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MY_POD_TYPE
+              value: node
+            - name: MY_NODE_CLASS
+              value: rolling-node
+            - name: DAEMON
+              value: upgrade-storage
+          volumeMounts:
+            - mountPath: /etc/tezos
+              name: config-volume
+            - mountPath: /var/tezos
+              name: var-volume
       securityContext:
         fsGroup: 100      
       volumes:

--- a/test/charts/mainnet2.expect.yaml
+++ b/test/charts/mainnet2.expect.yaml
@@ -449,7 +449,43 @@ spec:
             - mountPath: /etc/tezos
               name: config-volume
             - mountPath: /var/tezos
-              name: var-volume        
+              name: var-volume                
+        - name: upgrade-storage
+          image: "tezos/tezos:v14-release"
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+          args:
+            - "-c"
+            - |
+              set -ex
+              
+              tezos-node upgrade storage --data-dir /var/tezos/node/data
+          envFrom:
+            - configMapRef:
+                name: tezos-config
+          env:    
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MY_POD_TYPE
+              value: node
+            - name: MY_NODE_CLASS
+              value: city-block
+            - name: DAEMON
+              value: upgrade-storage
+            - name:  key
+              value: "outer-value"
+          volumeMounts:
+            - mountPath: /etc/tezos
+              name: config-volume
+            - mountPath: /var/tezos
+              name: var-volume
       securityContext:
         fsGroup: 100      
       volumes:
@@ -806,7 +842,43 @@ spec:
             - mountPath: /etc/tezos
               name: config-volume
             - mountPath: /var/tezos
-              name: var-volume        
+              name: var-volume                
+        - name: upgrade-storage
+          image: "tezos/tezos:v14-release"
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+          args:
+            - "-c"
+            - |
+              set -ex
+              
+              tezos-node upgrade storage --data-dir /var/tezos/node/data
+          envFrom:
+            - configMapRef:
+                name: tezos-config
+          env:    
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MY_POD_TYPE
+              value: node
+            - name: MY_NODE_CLASS
+              value: country-town
+            - name: DAEMON
+              value: upgrade-storage
+            - name:  key
+              value: "specific-pod"
+          volumeMounts:
+            - mountPath: /etc/tezos
+              name: config-volume
+            - mountPath: /var/tezos
+              name: var-volume
       securityContext:
         fsGroup: 100      
       volumes:

--- a/test/charts/private-chain.expect.yaml
+++ b/test/charts/private-chain.expect.yaml
@@ -520,6 +520,40 @@ spec:
             - mountPath: /etc/tezos
               name: config-volume
             - mountPath: /var/tezos
+              name: var-volume        
+        - name: upgrade-storage
+          image: "tezos/tezos:v14-release"
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+          args:
+            - "-c"
+            - |
+              set -ex
+              
+              tezos-node upgrade storage --data-dir /var/tezos/node/data
+          envFrom:
+            - configMapRef:
+                name: tezos-config
+          env:    
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MY_POD_TYPE
+              value: node
+            - name: MY_NODE_CLASS
+              value: af
+            - name: DAEMON
+              value: upgrade-storage
+          volumeMounts:
+            - mountPath: /etc/tezos
+              name: config-volume
+            - mountPath: /var/tezos
               name: var-volume
       securityContext:
         fsGroup: 100      
@@ -685,6 +719,40 @@ spec:
           env:
             - name: DAEMON
               value: wait-for-dns
+          volumeMounts:
+            - mountPath: /etc/tezos
+              name: config-volume
+            - mountPath: /var/tezos
+              name: var-volume        
+        - name: upgrade-storage
+          image: "tezos/tezos:v14-release"
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+          args:
+            - "-c"
+            - |
+              set -ex
+              
+              tezos-node upgrade storage --data-dir /var/tezos/node/data
+          envFrom:
+            - configMapRef:
+                name: tezos-config
+          env:    
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MY_POD_TYPE
+              value: node
+            - name: MY_NODE_CLASS
+              value: as
+            - name: DAEMON
+              value: upgrade-storage
           volumeMounts:
             - mountPath: /etc/tezos
               name: config-volume
@@ -985,6 +1053,40 @@ spec:
             - mountPath: /etc/tezos
               name: config-volume
             - mountPath: /var/tezos
+              name: var-volume        
+        - name: upgrade-storage
+          image: "tezos/tezos:v14-release"
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+          args:
+            - "-c"
+            - |
+              set -ex
+              
+              tezos-node upgrade storage --data-dir /var/tezos/node/data
+          envFrom:
+            - configMapRef:
+                name: tezos-config
+          env:    
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MY_POD_TYPE
+              value: node
+            - name: MY_NODE_CLASS
+              value: eu
+            - name: DAEMON
+              value: upgrade-storage
+          volumeMounts:
+            - mountPath: /etc/tezos
+              name: config-volume
+            - mountPath: /var/tezos
               name: var-volume
       securityContext:
         fsGroup: 100      
@@ -1214,6 +1316,40 @@ spec:
           env:
             - name: DAEMON
               value: wait-for-dns
+          volumeMounts:
+            - mountPath: /etc/tezos
+              name: config-volume
+            - mountPath: /var/tezos
+              name: var-volume        
+        - name: upgrade-storage
+          image: "tezos/tezos:v14-release"
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+          args:
+            - "-c"
+            - |
+              set -ex
+              
+              tezos-node upgrade storage --data-dir /var/tezos/node/data
+          envFrom:
+            - configMapRef:
+                name: tezos-config
+          env:    
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MY_POD_TYPE
+              value: node
+            - name: MY_NODE_CLASS
+              value: us
+            - name: DAEMON
+              value: upgrade-storage
           volumeMounts:
             - mountPath: /etc/tezos
               name: config-volume


### PR DESCRIPTION
This adds a fix for when the AWS API for the CSI driver fails and snapshots "hang" on `NotReady` status. This behavior is random and appears to be due to intermittent AWS API errors on AWS' end.

This simply checks for and deletes any snapshots that are older than 6m.  Generally snapshots don't exist for more than 4m or so.