### PR TITLE
Octez: Add storage upgrade container (for master branch and release)

### DIFF
--- a/charts/tezos/scripts/upgrade-storage.sh
+++ b/charts/tezos/scripts/upgrade-storage.sh
@@ -1,0 +1,3 @@
+set -ex
+
+tezos-node upgrade storage --data-dir /var/tezos/node/data

--- a/charts/tezos/templates/_containers.tpl
+++ b/charts/tezos/templates/_containers.tpl
@@ -229,6 +229,13 @@
   {{- end }}
 {{- end }}
 
+{{- define "tezos.init_container.upgrade_storage" }}
+    {{- include "tezos.generic_container" (dict "root"   $
+                                           "type"        "upgrade-storage"
+                                           "image"       "octez"
+    )  | nindent 0 }}
+{{- end }}
+
 {{- define "tezos.container.sidecar" }}
   {{- if or (not (hasKey $.node_vals "readiness_probe")) $.node_vals.readiness_probe }}
     {{- include "tezos.generic_container" (dict "root"  $

--- a/charts/tezos/templates/nodes.yaml
+++ b/charts/tezos/templates/nodes.yaml
@@ -47,6 +47,7 @@ spec:
         {{- include "tezos.init_container.snapshot_downloader" $ | indent 8 }}
         {{- include "tezos.init_container.snapshot_importer"   $ | indent 8 }}
         {{- include "tezos.init_container.wait_for_dns"        $ | indent 8 }}
+        {{- include "tezos.init_container.upgrade_storage"     $ | indent 8 }}
       securityContext:
         fsGroup: 100
 {{- include "tezos.nodeSelectorConfig" $ | indent 6 }}

--- a/test/charts/mainnet.expect.yaml
+++ b/test/charts/mainnet.expect.yaml
@@ -357,21 +357,7 @@ spec:
               
               tezos-node upgrade storage --data-dir /var/tezos/node/data
           envFrom:
-            - configMapRef:
-                name: tezos-config
-          env:    
-            - name: MY_POD_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIP
-            - name: MY_POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: MY_POD_TYPE
-              value: node
-            - name: MY_NODE_CLASS
-              value: rolling-node
+          env:
             - name: DAEMON
               value: upgrade-storage
           volumeMounts:

--- a/test/charts/mainnet.expect.yaml
+++ b/test/charts/mainnet.expect.yaml
@@ -344,7 +344,41 @@ spec:
             - mountPath: /etc/tezos
               name: config-volume
             - mountPath: /var/tezos
-              name: var-volume        
+              name: var-volume                
+        - name: upgrade-storage
+          image: "tezos/tezos:v14-release"
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+          args:
+            - "-c"
+            - |
+              set -ex
+              
+              tezos-node upgrade storage --data-dir /var/tezos/node/data
+          envFrom:
+            - configMapRef:
+                name: tezos-config
+          env:    
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MY_POD_TYPE
+              value: node
+            - name: MY_NODE_CLASS
+              value: rolling-node
+            - name: DAEMON
+              value: upgrade-storage
+          volumeMounts:
+            - mountPath: /etc/tezos
+              name: config-volume
+            - mountPath: /var/tezos
+              name: var-volume
       securityContext:
         fsGroup: 100      
       volumes:

--- a/test/charts/mainnet2.expect.yaml
+++ b/test/charts/mainnet2.expect.yaml
@@ -449,7 +449,43 @@ spec:
             - mountPath: /etc/tezos
               name: config-volume
             - mountPath: /var/tezos
-              name: var-volume        
+              name: var-volume                
+        - name: upgrade-storage
+          image: "tezos/tezos:v14-release"
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+          args:
+            - "-c"
+            - |
+              set -ex
+              
+              tezos-node upgrade storage --data-dir /var/tezos/node/data
+          envFrom:
+            - configMapRef:
+                name: tezos-config
+          env:    
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MY_POD_TYPE
+              value: node
+            - name: MY_NODE_CLASS
+              value: city-block
+            - name: DAEMON
+              value: upgrade-storage
+            - name:  key
+              value: "outer-value"
+          volumeMounts:
+            - mountPath: /etc/tezos
+              name: config-volume
+            - mountPath: /var/tezos
+              name: var-volume
       securityContext:
         fsGroup: 100      
       volumes:
@@ -806,7 +842,43 @@ spec:
             - mountPath: /etc/tezos
               name: config-volume
             - mountPath: /var/tezos
-              name: var-volume        
+              name: var-volume                
+        - name: upgrade-storage
+          image: "tezos/tezos:v14-release"
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+          args:
+            - "-c"
+            - |
+              set -ex
+              
+              tezos-node upgrade storage --data-dir /var/tezos/node/data
+          envFrom:
+            - configMapRef:
+                name: tezos-config
+          env:    
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MY_POD_TYPE
+              value: node
+            - name: MY_NODE_CLASS
+              value: country-town
+            - name: DAEMON
+              value: upgrade-storage
+            - name:  key
+              value: "specific-pod"
+          volumeMounts:
+            - mountPath: /etc/tezos
+              name: config-volume
+            - mountPath: /var/tezos
+              name: var-volume
       securityContext:
         fsGroup: 100      
       volumes:

--- a/test/charts/mainnet2.expect.yaml
+++ b/test/charts/mainnet2.expect.yaml
@@ -462,21 +462,7 @@ spec:
               
               tezos-node upgrade storage --data-dir /var/tezos/node/data
           envFrom:
-            - configMapRef:
-                name: tezos-config
-          env:    
-            - name: MY_POD_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIP
-            - name: MY_POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: MY_POD_TYPE
-              value: node
-            - name: MY_NODE_CLASS
-              value: city-block
+          env:
             - name: DAEMON
               value: upgrade-storage
             - name:  key
@@ -855,21 +841,7 @@ spec:
               
               tezos-node upgrade storage --data-dir /var/tezos/node/data
           envFrom:
-            - configMapRef:
-                name: tezos-config
-          env:    
-            - name: MY_POD_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIP
-            - name: MY_POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: MY_POD_TYPE
-              value: node
-            - name: MY_NODE_CLASS
-              value: country-town
+          env:
             - name: DAEMON
               value: upgrade-storage
             - name:  key

--- a/test/charts/private-chain.expect.yaml
+++ b/test/charts/private-chain.expect.yaml
@@ -520,6 +520,40 @@ spec:
             - mountPath: /etc/tezos
               name: config-volume
             - mountPath: /var/tezos
+              name: var-volume        
+        - name: upgrade-storage
+          image: "tezos/tezos:v14-release"
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+          args:
+            - "-c"
+            - |
+              set -ex
+              
+              tezos-node upgrade storage --data-dir /var/tezos/node/data
+          envFrom:
+            - configMapRef:
+                name: tezos-config
+          env:    
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MY_POD_TYPE
+              value: node
+            - name: MY_NODE_CLASS
+              value: af
+            - name: DAEMON
+              value: upgrade-storage
+          volumeMounts:
+            - mountPath: /etc/tezos
+              name: config-volume
+            - mountPath: /var/tezos
               name: var-volume
       securityContext:
         fsGroup: 100      
@@ -685,6 +719,40 @@ spec:
           env:
             - name: DAEMON
               value: wait-for-dns
+          volumeMounts:
+            - mountPath: /etc/tezos
+              name: config-volume
+            - mountPath: /var/tezos
+              name: var-volume        
+        - name: upgrade-storage
+          image: "tezos/tezos:v14-release"
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+          args:
+            - "-c"
+            - |
+              set -ex
+              
+              tezos-node upgrade storage --data-dir /var/tezos/node/data
+          envFrom:
+            - configMapRef:
+                name: tezos-config
+          env:    
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MY_POD_TYPE
+              value: node
+            - name: MY_NODE_CLASS
+              value: as
+            - name: DAEMON
+              value: upgrade-storage
           volumeMounts:
             - mountPath: /etc/tezos
               name: config-volume
@@ -985,6 +1053,40 @@ spec:
             - mountPath: /etc/tezos
               name: config-volume
             - mountPath: /var/tezos
+              name: var-volume        
+        - name: upgrade-storage
+          image: "tezos/tezos:v14-release"
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+          args:
+            - "-c"
+            - |
+              set -ex
+              
+              tezos-node upgrade storage --data-dir /var/tezos/node/data
+          envFrom:
+            - configMapRef:
+                name: tezos-config
+          env:    
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MY_POD_TYPE
+              value: node
+            - name: MY_NODE_CLASS
+              value: eu
+            - name: DAEMON
+              value: upgrade-storage
+          volumeMounts:
+            - mountPath: /etc/tezos
+              name: config-volume
+            - mountPath: /var/tezos
               name: var-volume
       securityContext:
         fsGroup: 100      
@@ -1214,6 +1316,40 @@ spec:
           env:
             - name: DAEMON
               value: wait-for-dns
+          volumeMounts:
+            - mountPath: /etc/tezos
+              name: config-volume
+            - mountPath: /var/tezos
+              name: var-volume        
+        - name: upgrade-storage
+          image: "tezos/tezos:v14-release"
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+          args:
+            - "-c"
+            - |
+              set -ex
+              
+              tezos-node upgrade storage --data-dir /var/tezos/node/data
+          envFrom:
+            - configMapRef:
+                name: tezos-config
+          env:    
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MY_POD_TYPE
+              value: node
+            - name: MY_NODE_CLASS
+              value: us
+            - name: DAEMON
+              value: upgrade-storage
           volumeMounts:
             - mountPath: /etc/tezos
               name: config-volume

--- a/test/charts/private-chain.expect.yaml
+++ b/test/charts/private-chain.expect.yaml
@@ -533,21 +533,7 @@ spec:
               
               tezos-node upgrade storage --data-dir /var/tezos/node/data
           envFrom:
-            - configMapRef:
-                name: tezos-config
-          env:    
-            - name: MY_POD_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIP
-            - name: MY_POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: MY_POD_TYPE
-              value: node
-            - name: MY_NODE_CLASS
-              value: af
+          env:
             - name: DAEMON
               value: upgrade-storage
           volumeMounts:
@@ -736,21 +722,7 @@ spec:
               
               tezos-node upgrade storage --data-dir /var/tezos/node/data
           envFrom:
-            - configMapRef:
-                name: tezos-config
-          env:    
-            - name: MY_POD_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIP
-            - name: MY_POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: MY_POD_TYPE
-              value: node
-            - name: MY_NODE_CLASS
-              value: as
+          env:
             - name: DAEMON
               value: upgrade-storage
           volumeMounts:
@@ -1066,21 +1038,7 @@ spec:
               
               tezos-node upgrade storage --data-dir /var/tezos/node/data
           envFrom:
-            - configMapRef:
-                name: tezos-config
-          env:    
-            - name: MY_POD_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIP
-            - name: MY_POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: MY_POD_TYPE
-              value: node
-            - name: MY_NODE_CLASS
-              value: eu
+          env:
             - name: DAEMON
               value: upgrade-storage
           volumeMounts:
@@ -1333,21 +1291,7 @@ spec:
               
               tezos-node upgrade storage --data-dir /var/tezos/node/data
           envFrom:
-            - configMapRef:
-                name: tezos-config
-          env:    
-            - name: MY_POD_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIP
-            - name: MY_POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: MY_POD_TYPE
-              value: node
-            - name: MY_NODE_CLASS
-              value: us
+          env:
             - name: DAEMON
               value: upgrade-storage
           volumeMounts:


### PR DESCRIPTION
This adds a storage init container to the master branch so we can release ahead of ghostnet/kathmandu activation.

See https://github.com/oxheadalpha/tezos-k8s/pull/486#issuecomment-1244943539 for why it is not parametrizable for now.

Includes efficiency suggested here by @harryttd  https://github.com/oxheadalpha/tezos-k8s/pull/486/files#r968888271

This is already implemented in the [monosite](https://github.com/oxheadalpha/tezos-k8s/commit/9b00e7df7d209ffddbdbafe103e59eb2b7582540#diff-551782c22fef270d6ceef4d2786b684f8e5585179b4f115ccac22653df0267bc) branch, but @nicolasochem said he wanted it for release on master this week.