### PR TITLE
kathmandu private chain by default

### DIFF
--- a/charts/tezos/scripts/upgrade-storage.sh
+++ b/charts/tezos/scripts/upgrade-storage.sh
@@ -1,3 +1,8 @@
 set -ex
 
+if [ ! -e /var/tezos/node/data ]
+then
+  printf "No data dir found, probably initial start, doing nothing."
+  exit 0
+fi
 tezos-node upgrade storage --data-dir /var/tezos/node/data

--- a/charts/tezos/values.yaml
+++ b/charts/tezos/values.yaml
@@ -320,7 +320,7 @@ protocols:
   ##   "on" and "off" must be between quotes.
   ## Note that we are not providing default votes since every baker needs
   ## to make an explicit educated choice on every toggle.
-  - command: 013-PtJakart
+  - command: 014-PtKathma
     vote: {}
   # - command: alpha
   #   vote:
@@ -332,7 +332,7 @@ protocols:
 ## after chain activation.
 ##
 # activation:
-#  protocol_hash: PtJakart2xVj7pYXJBXrqHgd82rdkLey5ZeeGwDgPp9rhQUbSqY
+#  protocol_hash: PtKathmankSpLLDALzWw7CGD2j2MtyveTwboEYokqUCP4a1LxMg
 #  protocol_parameters:
 #    preserved_cycles: 3
 #    blocks_per_cycle: 8

--- a/mkchain/tqchain/mkchain.py
+++ b/mkchain/tqchain/mkchain.py
@@ -189,7 +189,7 @@ def main():
         },
         "protocols": [
             {
-                "command": "013-PtJakart",
+                "command": "014-PtKathma",
                 "vote": {"liquidity_baking_toggle_vote": "pass"},
             }
         ],
@@ -295,7 +295,7 @@ def main():
         parametersYaml = yaml.safe_load(yaml_file)
         activation = {
             "activation": {
-                "protocol_hash": "PtJakart2xVj7pYXJBXrqHgd82rdkLey5ZeeGwDgPp9rhQUbSqY",
+                "protocol_hash": "PtKathmankSpLLDALzWw7CGD2j2MtyveTwboEYokqUCP4a1LxMg",
                 "protocol_parameters": parametersYaml,
             },
         }

--- a/mkchain/tqchain/parameters.yaml
+++ b/mkchain/tqchain/parameters.yaml
@@ -6,7 +6,7 @@ cycles_per_voting_period: 1
 hard_gas_limit_per_operation: '1040000'
 hard_gas_limit_per_block: '5200000'
 proof_of_work_threshold: '-1'
-tokens_per_roll: '8000000000'
+tokens_per_roll: '6000000000'
 seed_nonce_revelation_tip: '125000'
 baking_reward_fixed_portion: '10000000'
 baking_reward_bonus_per_slot: '4286'
@@ -37,11 +37,12 @@ ratio_of_frozen_deposits_slashed_per_double_endorsement:
 cache_script_size: 100000000
 cache_stake_distribution_cycles: 8
 cache_sampler_state_cycles: 8
+nonce_revelation_threshold: 4
+vdf_difficulty: '100000'
 tx_rollup_enable: true
 tx_rollup_origination_size: 4000
 tx_rollup_hard_size_limit_per_inbox: 500000
 tx_rollup_hard_size_limit_per_message: 5000
-tx_rollup_max_withdrawals_per_batch: 15
 tx_rollup_commitment_bond: "10000000000"
 tx_rollup_finality_period: 10
 tx_rollup_max_inboxes_count: 15
@@ -49,10 +50,22 @@ tx_rollup_withdraw_period: 10
 tx_rollup_max_messages_per_inbox: 1010
 tx_rollup_max_commitments_count: 30
 tx_rollup_cost_per_byte_ema_factor: 120
+tx_rollup_max_withdrawals_per_batch: 15
 tx_rollup_max_ticket_payload_size: 2048
 tx_rollup_rejection_max_proof_size: 30000
-tx_rollup_sunset_level: 17280
-sc_rollup_enable: false
+tx_rollup_sunset_level: 10000000
+dal_parametric:
+  feature_enable: true
+  number_of_slots: 256
+  number_of_shards: 2048
+  endorsement_lag: 2
+  availability_threshold: 50
+sc_rollup_enable: true
 sc_rollup_origination_size: 6314
 sc_rollup_challenge_window_in_blocks: 40
 sc_rollup_max_available_messages: 1000000
+sc_rollup_stake_amount: "32000000"
+sc_rollup_commitment_period_in_blocks: 20
+sc_rollup_max_lookahead_in_blocks: 30000
+sc_rollup_max_active_outbox_levels: 20160
+sc_rollup_max_outbox_messages_per_level: 100

--- a/test/charts/mainnet.expect.yaml
+++ b/test/charts/mainnet.expect.yaml
@@ -355,7 +355,13 @@ spec:
             - |
               set -ex
               
+              if [ ! -e /var/tezos/node/data ]
+              then
+                printf "No data dir found, probably initial start, doing nothing."
+                exit 0
+              fi
               tezos-node upgrade storage --data-dir /var/tezos/node/data
+              
           envFrom:
           env:
             - name: DAEMON

--- a/test/charts/mainnet2.expect.yaml
+++ b/test/charts/mainnet2.expect.yaml
@@ -460,7 +460,13 @@ spec:
             - |
               set -ex
               
+              if [ ! -e /var/tezos/node/data ]
+              then
+                printf "No data dir found, probably initial start, doing nothing."
+                exit 0
+              fi
               tezos-node upgrade storage --data-dir /var/tezos/node/data
+              
           envFrom:
           env:
             - name: DAEMON
@@ -839,7 +845,13 @@ spec:
             - |
               set -ex
               
+              if [ ! -e /var/tezos/node/data ]
+              then
+                printf "No data dir found, probably initial start, doing nothing."
+                exit 0
+              fi
               tezos-node upgrade storage --data-dir /var/tezos/node/data
+              
           envFrom:
           env:
             - name: DAEMON

--- a/test/charts/private-chain.expect.yaml
+++ b/test/charts/private-chain.expect.yaml
@@ -531,7 +531,13 @@ spec:
             - |
               set -ex
               
+              if [ ! -e /var/tezos/node/data ]
+              then
+                printf "No data dir found, probably initial start, doing nothing."
+                exit 0
+              fi
               tezos-node upgrade storage --data-dir /var/tezos/node/data
+              
           envFrom:
           env:
             - name: DAEMON
@@ -720,7 +726,13 @@ spec:
             - |
               set -ex
               
+              if [ ! -e /var/tezos/node/data ]
+              then
+                printf "No data dir found, probably initial start, doing nothing."
+                exit 0
+              fi
               tezos-node upgrade storage --data-dir /var/tezos/node/data
+              
           envFrom:
           env:
             - name: DAEMON
@@ -1036,7 +1048,13 @@ spec:
             - |
               set -ex
               
+              if [ ! -e /var/tezos/node/data ]
+              then
+                printf "No data dir found, probably initial start, doing nothing."
+                exit 0
+              fi
               tezos-node upgrade storage --data-dir /var/tezos/node/data
+              
           envFrom:
           env:
             - name: DAEMON
@@ -1289,7 +1307,13 @@ spec:
             - |
               set -ex
               
+              if [ ! -e /var/tezos/node/data ]
+              then
+                printf "No data dir found, probably initial start, doing nothing."
+                exit 0
+              fi
               tezos-node upgrade storage --data-dir /var/tezos/node/data
+              
           envFrom:
           env:
             - name: DAEMON


### PR DESCRIPTION
Make kathmandu the default protocol for new private chains.

Also repair private chain: don't update storage when there is none.