### PR TITLE
fix pre-configured identities

### DIFF
--- a/charts/tezos/scripts/upgrade-storage.sh
+++ b/charts/tezos/scripts/upgrade-storage.sh
@@ -1,8 +1,8 @@
 set -ex
 
-if [ ! -e /var/tezos/node/data ]
+if [ ! -e /var/tezos/node/data/context ]
 then
-  printf "No data dir found, probably initial start, doing nothing."
+  printf "No context in data dir found, probably initial start, doing nothing."
   exit 0
 fi
 tezos-node upgrade storage --data-dir /var/tezos/node/data

--- a/test/charts/mainnet.expect.yaml
+++ b/test/charts/mainnet.expect.yaml
@@ -355,9 +355,9 @@ spec:
             - |
               set -ex
               
-              if [ ! -e /var/tezos/node/data ]
+              if [ ! -e /var/tezos/node/data/context ]
               then
-                printf "No data dir found, probably initial start, doing nothing."
+                printf "No context in data dir found, probably initial start, doing nothing."
                 exit 0
               fi
               tezos-node upgrade storage --data-dir /var/tezos/node/data

--- a/test/charts/mainnet2.expect.yaml
+++ b/test/charts/mainnet2.expect.yaml
@@ -460,9 +460,9 @@ spec:
             - |
               set -ex
               
-              if [ ! -e /var/tezos/node/data ]
+              if [ ! -e /var/tezos/node/data/context ]
               then
-                printf "No data dir found, probably initial start, doing nothing."
+                printf "No context in data dir found, probably initial start, doing nothing."
                 exit 0
               fi
               tezos-node upgrade storage --data-dir /var/tezos/node/data
@@ -845,9 +845,9 @@ spec:
             - |
               set -ex
               
-              if [ ! -e /var/tezos/node/data ]
+              if [ ! -e /var/tezos/node/data/context ]
               then
-                printf "No data dir found, probably initial start, doing nothing."
+                printf "No context in data dir found, probably initial start, doing nothing."
                 exit 0
               fi
               tezos-node upgrade storage --data-dir /var/tezos/node/data

--- a/test/charts/private-chain.expect.yaml
+++ b/test/charts/private-chain.expect.yaml
@@ -531,9 +531,9 @@ spec:
             - |
               set -ex
               
-              if [ ! -e /var/tezos/node/data ]
+              if [ ! -e /var/tezos/node/data/context ]
               then
-                printf "No data dir found, probably initial start, doing nothing."
+                printf "No context in data dir found, probably initial start, doing nothing."
                 exit 0
               fi
               tezos-node upgrade storage --data-dir /var/tezos/node/data
@@ -726,9 +726,9 @@ spec:
             - |
               set -ex
               
-              if [ ! -e /var/tezos/node/data ]
+              if [ ! -e /var/tezos/node/data/context ]
               then
-                printf "No data dir found, probably initial start, doing nothing."
+                printf "No context in data dir found, probably initial start, doing nothing."
                 exit 0
               fi
               tezos-node upgrade storage --data-dir /var/tezos/node/data
@@ -1048,9 +1048,9 @@ spec:
             - |
               set -ex
               
-              if [ ! -e /var/tezos/node/data ]
+              if [ ! -e /var/tezos/node/data/context ]
               then
-                printf "No data dir found, probably initial start, doing nothing."
+                printf "No context in data dir found, probably initial start, doing nothing."
                 exit 0
               fi
               tezos-node upgrade storage --data-dir /var/tezos/node/data
@@ -1307,9 +1307,9 @@ spec:
             - |
               set -ex
               
-              if [ ! -e /var/tezos/node/data ]
+              if [ ! -e /var/tezos/node/data/context ]
               then
-                printf "No data dir found, probably initial start, doing nothing."
+                printf "No context in data dir found, probably initial start, doing nothing."
                 exit 0
               fi
               tezos-node upgrade storage --data-dir /var/tezos/node/data

--- a/utils/config-generator.py
+++ b/utils/config-generator.py
@@ -431,8 +431,8 @@ def create_node_identity_json():
         print(json.dumps(NODE_IDENTITIES.get(MY_POD_NAME)), file=identity_file)
 
     nogroup = getgrnam("nogroup").gr_gid
-    chown(DATA_DIR, user=100, group=nogroup)
-    chown(identity_file_path, user=100, group=nogroup)
+    chown(DATA_DIR, user=1000, group=nogroup)
+    chown(identity_file_path, user=1000, group=nogroup)
     print(f"Identity file written at {identity_file_path}")
 
 


### PR DESCRIPTION
There were two issues:

1. the logic that avoid performing storage upgrades when there is no storage was merely checking the existence of /var/tezos/node/data. But in case of [pre-generated identity passed in values.yaml](https://github.com/oxheadalpha/tezos-k8s/blob/master/charts/tezos/values.yaml#L148-L153), we write a identity.json in this dir, so the node still tries to perform the upgrade and fails, failing the pod. So now, we check for the existence of the context dir, which will only exist in subsequent starts, or after snapshot or tarball import
2. The identity owner was set to the old uid of 100, setting it now to the new uid of 1000. (not sure if it is an actual problem, but I initially thought it was, so I fixed it either way)