### PR TITLE
remove VDF conditional on protocol

### DIFF
--- a/charts/tezos/templates/_containers.tpl
+++ b/charts/tezos/templates/_containers.tpl
@@ -319,10 +319,6 @@
   {{- if has "vdf" $.node_vals.runs }}
   {{ $node_vals_images := $.node_vals.images | default dict }}
     {{- range .Values.protocols }}
-      {{- if or (regexFind "Kathma" .command) (regexFind "alpha" .command) }}
-      {{- /*
-      Only protos higher than Kathmandu support VDF
-      */}}
 - name: vdf-{{ lower .command }}
   image: "{{ or $node_vals_images.octez $.Values.images.octez }}"
   imagePullPolicy: IfNotPresent
@@ -331,7 +327,6 @@
   args:
     - run
     - vdf
-      {{- end }}
     {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
After jakarta deprecation, every protocol now supports VDF daemon, so we remove the conditional. This conditional was temporary to support jakarta (which has no VDF daemon)