### PR TITLE
Move containers from docker hub to github registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ jobs:
       id: meta
       uses: docker/metadata-action@v3
       with:
-        images: ghcr.io/${{ github.repository_owner }}/${{ matrix.container }}
+        images: ghcr.io/${{ github.repository_owner }}/tezos-k8s-${{ matrix.container }}
         tags: |
           type=ref,event=branch
           type=ref,event=pr

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,60 +140,37 @@ jobs:
           echo $container_list
           echo "::set-output name=matrix::$container_list"
 
-  publish_containers:
-    # based on
-    # https://github.com/docker/build-push-action#usage
+  publish-to-ghcr:
     runs-on: ubuntu-latest
     needs: list_containers_to_publish
-    if: github.event_name == 'release' && github.event.action == 'created'
     strategy:
       matrix: ${{fromJson(needs.list_containers_to_publish.outputs.matrix)}}
 
     steps:
-      - uses: actions/checkout@v2
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        submodules: 'true'
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+    - name: Login to registry
+      run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+    - name: Docker meta
+      id: meta
+      uses: docker/metadata-action@v3
+      with:
+        images: ghcr.io/${{ github.repository_owner }}/${{ matrix.container }}
+        tags: |
+          type=ref,event=branch
+          type=ref,event=pr
+          type=match,pattern=v(.*),group=1
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-
-      - name: Create docker hub ${{ matrix.container }} repo if not exists
-        # requires a github username and password rather than a token, unfortunately
-        # https://github.com/docker/hub-feedback/issues/1914
-        run: |
-          USER=${{ secrets.DOCKERHUB_USERNAME }}
-          PASS=${{ secrets.DOCKERHUB_PASSWORD }}
-          TOKEN=$(curl -s -H "Content-Type: application/json" -X POST -d '{"username": "'${USER}'", "password": "'${PASS}'"}' https://hub.docker.com/v2/users/login/ | jq -r .token)
-
-          curl -s -H "Authorization: JWT ${TOKEN}" "https://hub.docker.com/v2/repositories/" \
-          --data 'description="tezos-k8s ${{ matrix.container }}"' \
-          --data 'full_description="The container for https://github.com/oxheadalpha/tezos-k8s/tree/master/${{ matrix.container }}' \
-          --data 'is_private=false' \
-          --data 'name=tezos-k8s-${{ matrix.container }}' \
-          --data "namespace=oxheadalpha" || true
-
-      - name: Docker meta
-        id: docker_meta
-        uses: crazy-max/ghaction-docker-meta@v1
-        with:
-          images: oxheadalpha/tezos-k8s-${{ matrix.container }}
-          tag-sha: true
-
-      - name: Publish ${{ matrix.container }} container to Docker Hub
-        uses: docker/build-push-action@v2
-        with:
-          context: ${{ matrix.container }}/.
-          file: ${{ matrix.container }}/Dockerfile
-          push: true
-          tags: ${{ steps.docker_meta.outputs.tags }}
-          labels: ${{ steps.docker_meta.outputs.labels }}
+    - name: Push ${{ matrix.container }} container to GHCR
+      uses: docker/build-push-action@v2
+      with:
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        file: Dockerfile
 
   lint_helm_charts:
     runs-on: ubuntu-latest
@@ -260,7 +237,7 @@ jobs:
             # Update the release version of each of tezos-k8s images
             for image in $tq_images; do
               image_name=$(yq e ".tezos_k8s_images.$image" $chart/values.yaml | sed -E "s/tezos-k8s-(.*):.*/\1/")
-              yq e ".tezos_k8s_images.$image = \"oxheadalpha/tezos-k8s-$image_name:$RELEASE_VERSION\"" -i $chart/values.yaml
+              yq e ".tezos_k8s_images.$image = \"ghcr.io/oxheadalpha/tezos-k8s-$image_name:$RELEASE_VERSION\"" -i $chart/values.yaml
             done
           done
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,8 @@ jobs:
         push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
-        file: Dockerfile
+        file: ${{ matrix.container }}/Dockerfile
+        context: ${{ matrix.container}}/.
 
   lint_helm_charts:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,7 +203,7 @@ jobs:
 
   publish_helm_charts:
     runs-on: ubuntu-latest
-    needs: [test-helm-charts, lint_helm_charts, publish_containers]
+    needs: [test-helm-charts, lint_helm_charts, publish-to-ghcr]
     if: github.event_name == 'release' && github.event.action == 'created'
     steps:
       - name: Checkout


### PR DESCRIPTION
There are many advantages:
* it's better integrated with github
* when we add a new container, the package gets added automatically without any hack (we had to use a hack in docker hub because there is no API for adding a container)
* we can generate containers for every branch and PR

Besides it's totally transparent to the user: most users use our released helm charts wihch have the container path hardcoded (the `publish_helm` action takes care of this): here, I am just hardcoding the ghcr.io URL instead of the default docker hub location for all our packages.

So, there is no user-facing impact on this.

I want to go further and suggest that we change our submodule workflow.

Today, when we want to test a branch of tezos-k8s, we typically check out a submodule inside the infra repo and we have some logic to build containers within the submodule and push them to AWS ECR.

Instead, I am suggesting a new workflow: whenever we do a change to tezos-k8s, we have to set the tag for the PR build for every image inside of values.yaml. Submodules are still needed in case we change the helm chart, but we no longer build the containers in the submodule.

* **PRO**: we solve the problem of "leaky" submods: we had cases where different charts were on different submodules within a single repo, but it was all being pushed to a signle ECR registry and for some reason the builds were getting mixed up between namespaces
* **PRO**: faster deployments. The ECR workflow requires to build and push containers, which is fast locally in theory because of docker caching, but still heavy and slower than release deploys in my experience. Also, when using actions, there was no caching so a submod deploy was taking much longer
* **PRO**: we remove the dependency on AWS: this works on any k8s cluster now
* **CON**: we can't deploy with local changes from laptop. Any change has to be pushed to a branch (it can be on a fork if the code is not yet appropriate for pushing upstream)
* **CON**: we have to remember to set the tag to the PR build, then revert to release after release (although this could be fixed with a bit of extra logic in the code where we decide whether submod/release to build the helm params)

What do yall think?