### PR TITLE
Service monitor

### DIFF
--- a/charts/tezos/templates/_containers.tpl
+++ b/charts/tezos/templates/_containers.tpl
@@ -343,34 +343,6 @@
   {{- end }}
 {{- end }}
 
-{{- define "tezos.container.metrics" }}
-{{- if has "metrics" $.node_vals.runs }}
-- image: "registry.gitlab.com/nomadic-labs/tezos-metrics"
-  args:
-    - "--listen-prometheus=6666"
-    - "--data-dir=/var/tezos/node/data"
-  imagePullPolicy: IfNotPresent
-  name: metrics
-  ports:
-    - containerPort: 6666
-      name: tezos-metrics
-  volumeMounts:
-    - mountPath: /etc/tezos
-      name: config-volume
-    - mountPath: /var/tezos
-      name: var-volume
-    - mountPath: /etc/secret-volume
-      name: tezos-accounts
-  envFrom:
-    - configMapRef:
-        name: tezos-config
-  env:
-{{- include "tezos.localvars.pod_envvars" . | indent 4 }}
-    - name: DAEMON
-      value: tezos-metrics
-{{- end }}
-{{- end }}
-
 {{/*
 // * The zerotier containers:
 */}}

--- a/charts/tezos/templates/_containers.tpl
+++ b/charts/tezos/templates/_containers.tpl
@@ -156,10 +156,10 @@
   ports:
     - containerPort: 8732
       name: tezos-rpc
-    - containerPort: 9001
-      name: metrics
     - containerPort: 9732
       name: tezos-net
+    - containerPort: 9932
+      name: metrics
     {{- if or (not (hasKey $.node_vals "readiness_probe")) $.node_vals.readiness_probe }}
   readinessProbe:
     httpGet:

--- a/charts/tezos/templates/_containers.tpl
+++ b/charts/tezos/templates/_containers.tpl
@@ -156,6 +156,8 @@
   ports:
     - containerPort: 8732
       name: tezos-rpc
+    - containerPort: 9001
+      name: metrics
     - containerPort: 9732
       name: tezos-net
     {{- if or (not (hasKey $.node_vals "readiness_probe")) $.node_vals.readiness_probe }}

--- a/charts/tezos/templates/nodes.yaml
+++ b/charts/tezos/templates/nodes.yaml
@@ -36,7 +36,6 @@ spec:
         {{- include "tezos.container.accusers"  $ | indent 8 }}
         {{- include "tezos.container.bakers"    $ | indent 8 }}
         {{- include "tezos.container.logger"    $ | indent 8 }}
-        {{- include "tezos.container.metrics"   $ | indent 8 }}
         {{- include "tezos.container.zerotier"  $ | indent 8 }}
         {{- include "tezos.container.sidecar"   $ | indent 8 }}
         {{- include "tezos.container.vdf"       $ | indent 8 }}

--- a/charts/tezos/templates/servicemonitor.yaml
+++ b/charts/tezos/templates/servicemonitor.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    appType: tezos-node
+  name: tezos-service-monitor
+  namespace: {{ .Release.Namespace }}
+spec:
+  endpoints:
+  - interval: 15s
+    port: metrics
+    path: /metrics
+  selector:
+    matchLabels:
+      appType: tezos-node
+{{- end }}

--- a/charts/tezos/templates/servicemonitor.yaml
+++ b/charts/tezos/templates/servicemonitor.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    appType: tezos-node
+{{- toYaml .Values.serviceMonitor.labels | nindent 4 }}
   name: tezos-service-monitor
   namespace: {{ .Release.Namespace }}
 spec:

--- a/charts/tezos/templates/static.yaml
+++ b/charts/tezos/templates/static.yaml
@@ -18,11 +18,13 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ $key }}
+  labels:
+    appType: tezos-node
 spec:
   ports:
     - port: 9732
       name: p2p
-    - port: 9001
+    - port: 9932
       name: metrics
   publishNotReadyAddresses: true
   clusterIP: None

--- a/charts/tezos/templates/static.yaml
+++ b/charts/tezos/templates/static.yaml
@@ -19,6 +19,11 @@ kind: Service
 metadata:
   name: {{ $key }}
 spec:
+  ports:
+    - port: 9732
+      name: p2p
+    - port: 9001
+      name: metrics
   publishNotReadyAddresses: true
   clusterIP: None
   selector:

--- a/charts/tezos/values.yaml
+++ b/charts/tezos/values.yaml
@@ -230,7 +230,7 @@ nodes:
         config:
           shell:
             history_mode: rolling
-          metrics_addr: [ ":9091" ]
+          metrics_addr: [ "0.0.0.0:9932" ]
 # End nodes
 
 ## Configuration for K8s Service resources. Configuring the labels selector of a
@@ -247,10 +247,12 @@ services:
 # serviceMonitor below.
 # ServiceMonitor allows you to scrape the prometheus endpoints of your tezos nodes.
 # Make sure the endpoints are active by adding:
-#     metrics_addr: [ ":9091" ]
+#     metrics_addr: [ ":9932" ]
 # to your config.
 serviceMonitor:
   enabled: false
+  labels:
+    # release: my-monitoring-release
 
 # # Signers
 #

--- a/charts/tezos/values.yaml
+++ b/charts/tezos/values.yaml
@@ -230,6 +230,7 @@ nodes:
         config:
           shell:
             history_mode: rolling
+          metrics_addr: [ ":9091" ]
 # End nodes
 
 ## Configuration for K8s Service resources. Configuring the labels selector of a
@@ -241,6 +242,15 @@ services:
   tezos_node_rpc:
     selector:
 #      rpc_node: "true"
+
+# Prometheus Operator is required in your cluster in order to enable
+# serviceMonitor below.
+# ServiceMonitor allows you to scrape the prometheus endpoints of your tezos nodes.
+# Make sure the endpoints are active by adding:
+#     metrics_addr: [ ":9091" ]
+# to your config.
+serviceMonitor:
+  enabled: false
 
 # # Signers
 #

--- a/charts/tezos/values.yaml
+++ b/charts/tezos/values.yaml
@@ -121,7 +121,7 @@ should_generate_unsafe_deterministic_data: false
 #           field up above.
 # - "runs": A list of containers to run. A tezos node implementation is required.
 #         Options being "octez_node" or "tezedge_node". Other optional
-#         containers are "accuser", "baker", "logger", "vdf" and "metrics".
+#         containers are "accuser", "baker", "logger" and "vdf".
 # - "local_storage": use local storage instead of a volume. The storage will be
 #                  wiped when the node restarts for any reason. Useful when
 #                  faster IO is desired. Defaults to false.

--- a/mkchain/tqchain/mkchain.py
+++ b/mkchain/tqchain/mkchain.py
@@ -151,7 +151,7 @@ def node_config(name, n, is_baker):
         "is_bootstrap_node": False,
         "config": {
             "shell": {"history_mode": "rolling"},
-            "metrics_addr": [ ":9001" ],
+            "metrics_addr": [ ":9932" ],
         },
     }
     if is_baker:

--- a/mkchain/tqchain/mkchain.py
+++ b/mkchain/tqchain/mkchain.py
@@ -151,6 +151,7 @@ def node_config(name, n, is_baker):
         "is_bootstrap_node": False,
         "config": {
             "shell": {"history_mode": "rolling"},
+            "metrics_addr": [ ":9001" ],
         },
     }
     if is_baker:

--- a/mkchain/tqchain/mkchain.py
+++ b/mkchain/tqchain/mkchain.py
@@ -151,7 +151,7 @@ def node_config(name, n, is_baker):
         "is_bootstrap_node": False,
         "config": {
             "shell": {"history_mode": "rolling"},
-            "metrics_addr": [ ":9932" ],
+            "metrics_addr": [":9932"],
         },
     }
     if is_baker:

--- a/test/charts/mainnet.expect.yaml
+++ b/test/charts/mainnet.expect.yaml
@@ -42,6 +42,9 @@ data:
         "instances": [
           {
             "config": {
+              "metrics_addr": [
+                "0.0.0.0:9932"
+              ],
               "shell": {
                 "history_mode": "rolling"
               }
@@ -82,7 +85,14 @@ apiVersion: v1
 kind: Service
 metadata:
   name: rolling-node
+  labels:
+    appType: tezos-node
 spec:
+  ports:
+    - port: 9732
+      name: p2p
+    - port: 9932
+      name: metrics
   publishNotReadyAddresses: true
   clusterIP: None
   selector:
@@ -153,6 +163,8 @@ spec:
               name: tezos-rpc
             - containerPort: 9732
               name: tezos-net
+            - containerPort: 9932
+              name: metrics
           readinessProbe:
             httpGet:
               path: /is_synced

--- a/test/charts/mainnet.expect.yaml
+++ b/test/charts/mainnet.expect.yaml
@@ -168,7 +168,7 @@ spec:
           readinessProbe:
             httpGet:
               path: /is_synced
-              port: 31732                                                        
+              port: 31732                                                
         - name: sidecar
           image: "tezos-k8s-utils:dev"
           imagePullPolicy: IfNotPresent

--- a/test/charts/mainnet2.expect.yaml
+++ b/test/charts/mainnet2.expect.yaml
@@ -233,41 +233,7 @@ spec:
             - mountPath: /etc/tezos
               name: config-volume
             - mountPath: /var/tezos
-              name: var-volume        
-        - image: "registry.gitlab.com/nomadic-labs/tezos-metrics"
-          args:
-            - "--listen-prometheus=6666"
-            - "--data-dir=/var/tezos/node/data"
-          imagePullPolicy: IfNotPresent
-          name: metrics
-          ports:
-            - containerPort: 6666
-              name: tezos-metrics
-          volumeMounts:
-            - mountPath: /etc/tezos
-              name: config-volume
-            - mountPath: /var/tezos
-              name: var-volume
-            - mountPath: /etc/secret-volume
-              name: tezos-accounts
-          envFrom:
-            - configMapRef:
-                name: tezos-config
-          env:    
-            - name: MY_POD_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIP
-            - name: MY_POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: MY_POD_TYPE
-              value: node
-            - name: MY_NODE_CLASS
-              value: city-block
-            - name: DAEMON
-              value: tezos-metrics                
+              name: var-volume                
         - name: sidecar
           image: "tezos-k8s-utils:dev"
           imagePullPolicy: IfNotPresent
@@ -620,41 +586,7 @@ spec:
             - mountPath: /etc/tezos
               name: config-volume
             - mountPath: /var/tezos
-              name: var-volume        
-        - image: "registry.gitlab.com/nomadic-labs/tezos-metrics"
-          args:
-            - "--listen-prometheus=6666"
-            - "--data-dir=/var/tezos/node/data"
-          imagePullPolicy: IfNotPresent
-          name: metrics
-          ports:
-            - containerPort: 6666
-              name: tezos-metrics
-          volumeMounts:
-            - mountPath: /etc/tezos
-              name: config-volume
-            - mountPath: /var/tezos
-              name: var-volume
-            - mountPath: /etc/secret-volume
-              name: tezos-accounts
-          envFrom:
-            - configMapRef:
-                name: tezos-config
-          env:    
-            - name: MY_POD_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIP
-            - name: MY_POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: MY_POD_TYPE
-              value: node
-            - name: MY_NODE_CLASS
-              value: country-town
-            - name: DAEMON
-              value: tezos-metrics                
+              name: var-volume                
         - name: sidecar
           image: "tezos-k8s-utils:dev"
           imagePullPolicy: IfNotPresent

--- a/test/charts/mainnet2.expect.yaml
+++ b/test/charts/mainnet2.expect.yaml
@@ -124,7 +124,14 @@ apiVersion: v1
 kind: Service
 metadata:
   name: city-block
+  labels:
+    appType: tezos-node
 spec:
+  ports:
+    - port: 9732
+      name: p2p
+    - port: 9932
+      name: metrics
   publishNotReadyAddresses: true
   clusterIP: None
   selector:
@@ -135,7 +142,14 @@ apiVersion: v1
 kind: Service
 metadata:
   name: country-town
+  labels:
+    appType: tezos-node
 spec:
+  ports:
+    - port: 9732
+      name: p2p
+    - port: 9932
+      name: metrics
   publishNotReadyAddresses: true
   clusterIP: None
   selector:
@@ -184,6 +198,8 @@ spec:
               name: tezos-rpc
             - containerPort: 9732
               name: tezos-net
+            - containerPort: 9932
+              name: metrics
           readinessProbe:
             httpGet:
               path: /is_synced
@@ -569,6 +585,8 @@ spec:
               name: tezos-rpc
             - containerPort: 9732
               name: tezos-net
+            - containerPort: 9932
+              name: metrics
           readinessProbe:
             httpGet:
               path: /is_synced

--- a/test/charts/private-chain.expect.yaml
+++ b/test/charts/private-chain.expect.yaml
@@ -236,7 +236,14 @@ apiVersion: v1
 kind: Service
 metadata:
   name: af
+  labels:
+    appType: tezos-node
 spec:
+  ports:
+    - port: 9732
+      name: p2p
+    - port: 9932
+      name: metrics
   publishNotReadyAddresses: true
   clusterIP: None
   selector:
@@ -247,7 +254,14 @@ apiVersion: v1
 kind: Service
 metadata:
   name: as
+  labels:
+    appType: tezos-node
 spec:
+  ports:
+    - port: 9732
+      name: p2p
+    - port: 9932
+      name: metrics
   publishNotReadyAddresses: true
   clusterIP: None
   selector:
@@ -258,7 +272,14 @@ apiVersion: v1
 kind: Service
 metadata:
   name: eu
+  labels:
+    appType: tezos-node
 spec:
+  ports:
+    - port: 9732
+      name: p2p
+    - port: 9932
+      name: metrics
   publishNotReadyAddresses: true
   clusterIP: None
   selector:
@@ -269,7 +290,14 @@ apiVersion: v1
 kind: Service
 metadata:
   name: us
+  labels:
+    appType: tezos-node
 spec:
+  ports:
+    - port: 9732
+      name: p2p
+    - port: 9932
+      name: metrics
   publishNotReadyAddresses: true
   clusterIP: None
   selector:
@@ -317,6 +345,8 @@ spec:
               name: tezos-rpc
             - containerPort: 9732
               name: tezos-net
+            - containerPort: 9932
+              name: metrics
           readinessProbe:
             httpGet:
               path: /is_synced
@@ -637,6 +667,8 @@ spec:
               name: tezos-rpc
             - containerPort: 9732
               name: tezos-net
+            - containerPort: 9932
+              name: metrics
           readinessProbe:
             httpGet:
               path: /is_synced
@@ -834,6 +866,8 @@ spec:
               name: tezos-rpc
             - containerPort: 9732
               name: tezos-net
+            - containerPort: 9932
+              name: metrics
           readinessProbe:
             httpGet:
               path: /is_synced
@@ -1155,6 +1189,8 @@ spec:
               name: tezos-rpc
             - containerPort: 9732
               name: tezos-net
+            - containerPort: 9932
+              name: metrics
           readinessProbe:
             httpGet:
               path: /is_synced

--- a/test/charts/private-chain.expect.yaml
+++ b/test/charts/private-chain.expect.yaml
@@ -441,41 +441,7 @@ spec:
             - mountPath: /etc/tezos
               name: config-volume
             - mountPath: /var/tezos
-              name: var-volume        
-        - image: "registry.gitlab.com/nomadic-labs/tezos-metrics"
-          args:
-            - "--listen-prometheus=6666"
-            - "--data-dir=/var/tezos/node/data"
-          imagePullPolicy: IfNotPresent
-          name: metrics
-          ports:
-            - containerPort: 6666
-              name: tezos-metrics
-          volumeMounts:
-            - mountPath: /etc/tezos
-              name: config-volume
-            - mountPath: /var/tezos
-              name: var-volume
-            - mountPath: /etc/secret-volume
-              name: tezos-accounts
-          envFrom:
-            - configMapRef:
-                name: tezos-config
-          env:    
-            - name: MY_POD_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIP
-            - name: MY_POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: MY_POD_TYPE
-              value: node
-            - name: MY_NODE_CLASS
-              value: af
-            - name: DAEMON
-              value: tezos-metrics                
+              name: var-volume                
         - name: sidecar
           image: "tezos-k8s-utils:dev"
           imagePullPolicy: IfNotPresent
@@ -672,7 +638,7 @@ spec:
           readinessProbe:
             httpGet:
               path: /is_synced
-              port: 31732                                                        
+              port: 31732                                                
         - name: sidecar
           image: "tezos-k8s-utils:dev"
           imagePullPolicy: IfNotPresent
@@ -962,41 +928,7 @@ spec:
             - mountPath: /etc/tezos
               name: config-volume
             - mountPath: /var/tezos
-              name: var-volume        
-        - image: "registry.gitlab.com/nomadic-labs/tezos-metrics"
-          args:
-            - "--listen-prometheus=6666"
-            - "--data-dir=/var/tezos/node/data"
-          imagePullPolicy: IfNotPresent
-          name: metrics
-          ports:
-            - containerPort: 6666
-              name: tezos-metrics
-          volumeMounts:
-            - mountPath: /etc/tezos
-              name: config-volume
-            - mountPath: /var/tezos
-              name: var-volume
-            - mountPath: /etc/secret-volume
-              name: tezos-accounts
-          envFrom:
-            - configMapRef:
-                name: tezos-config
-          env:    
-            - name: MY_POD_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIP
-            - name: MY_POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: MY_POD_TYPE
-              value: node
-            - name: MY_NODE_CLASS
-              value: eu
-            - name: DAEMON
-              value: tezos-metrics                
+              name: var-volume                
         - name: sidecar
           image: "tezos-k8s-utils:dev"
           imagePullPolicy: IfNotPresent
@@ -1257,7 +1189,7 @@ spec:
             - mountPath: /var/tezos
               name: var-volume
             - mountPath: /etc/tezos/per-block-votes
-              name: per-block-votes                                
+              name: per-block-votes                        
         - name: sidecar
           image: "tezos-k8s-utils:dev"
           imagePullPolicy: IfNotPresent


### PR DESCRIPTION
Add a service monitor to target the new metrics endpoint of v14.

Also remove the old "metrics" container since it is deprecated and replaced by the native endpoint.

Also add a serviceMonitor for convenience. We already have a service monitor in the pyrometer chart, I'm adding a similar one here. This helps the user not writing their own monitor, and saves a step in the upcoming guide.