### PR TITLE
fix GHCR tagging logic for releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,7 @@ jobs:
         tags: |
           type=ref,event=branch
           type=ref,event=pr
-          type=match,pattern=v(.*),group=1
+          type=match,pattern=([0-9]+\.[0-9]+\.[0-9]+),group=1
 
     - name: Push ${{ matrix.container }} container to GHCR
       uses: docker/build-push-action@v2


### PR DESCRIPTION
GHCR tagging logic does not match our convention. Set the right regex for detecting release tags.