### PR TITLE
Default image tags should be master, not latest

### DIFF
--- a/charts/pyrometer/values.yaml
+++ b/charts/pyrometer/values.yaml
@@ -1,7 +1,7 @@
 images:
   pyrometer: registry.gitlab.com/tezos-kiln/pyrometer:latest
 tezos_k8s_images:
-  utils: ghcr.io/oxheadalpha/tezos-k8s-utils:latest
+  utils: ghcr.io/oxheadalpha/tezos-k8s-utils:master
 # Pass below the pyrometer config, in yaml format
 config:
   node_monitor:

--- a/charts/snapshotEngine/values.yaml
+++ b/charts/snapshotEngine/values.yaml
@@ -1,5 +1,5 @@
 tezos_k8s_images:
-  snapshotEngine: ghcr.io/oxheadalpha/tezos-k8s-snapshotengine:latest
+  snapshotEngine: ghcr.io/oxheadalpha/tezos-k8s-snapshotengine:master
 
 # the tezos version used to run `tezos-node snapshot import/export`
 images:

--- a/charts/tezos/values.yaml
+++ b/charts/tezos/values.yaml
@@ -12,8 +12,8 @@ images:
   tezedge: tezedge/tezedge:v1.6.8
 # Images that are part of the tezos-k8s repo go here with 'dev' tag
 tezos_k8s_images:
-  utils: ghcr.io/oxheadalpha/tezos-k8s-utils:latest
-  zerotier: ghcr.io/oxheadalpha/tezos-k8s-zerotier:latest
+  utils: ghcr.io/oxheadalpha/tezos-k8s-utils:master
+  zerotier: ghcr.io/oxheadalpha/tezos-k8s-zerotier:master
 
 ## Properties that are templated for some k8s resources. There are container
 ## scripts that will look up some of these values. They should not be modified.

--- a/test/charts/mainnet.expect.yaml
+++ b/test/charts/mainnet.expect.yaml
@@ -170,7 +170,7 @@ spec:
               path: /is_synced
               port: 31732                                                
         - name: sidecar
-          image: "ghcr.io/oxheadalpha/tezos-k8s-utils:latest"
+          image: "ghcr.io/oxheadalpha/tezos-k8s-utils:master"
           imagePullPolicy: IfNotPresent
           args:
             - sidecar
@@ -245,7 +245,7 @@ spec:
             - mountPath: /var/tezos
               name: var-volume                
         - name: config-generator
-          image: "ghcr.io/oxheadalpha/tezos-k8s-utils:latest"
+          image: "ghcr.io/oxheadalpha/tezos-k8s-utils:master"
           imagePullPolicy: IfNotPresent
           args:
             - config-generator
@@ -275,7 +275,7 @@ spec:
             - mountPath: /etc/secret-volume
               name: tezos-accounts        
         - name: snapshot-downloader
-          image: "ghcr.io/oxheadalpha/tezos-k8s-utils:latest"
+          image: "ghcr.io/oxheadalpha/tezos-k8s-utils:master"
           imagePullPolicy: IfNotPresent
           args:
             - snapshot-downloader

--- a/test/charts/mainnet2.expect.yaml
+++ b/test/charts/mainnet2.expect.yaml
@@ -205,7 +205,7 @@ spec:
               path: /is_synced
               port: 31732                        
         - name: logger
-          image: "ghcr.io/oxheadalpha/tezos-k8s-utils:latest"
+          image: "ghcr.io/oxheadalpha/tezos-k8s-utils:master"
           imagePullPolicy: IfNotPresent
           args:
             - logger
@@ -235,7 +235,7 @@ spec:
             - mountPath: /var/tezos
               name: var-volume                
         - name: sidecar
-          image: "ghcr.io/oxheadalpha/tezos-k8s-utils:latest"
+          image: "ghcr.io/oxheadalpha/tezos-k8s-utils:master"
           imagePullPolicy: IfNotPresent
           args:
             - sidecar
@@ -314,7 +314,7 @@ spec:
             - mountPath: /var/tezos
               name: var-volume                
         - name: config-generator
-          image: "ghcr.io/oxheadalpha/tezos-k8s-utils:latest"
+          image: "ghcr.io/oxheadalpha/tezos-k8s-utils:master"
           imagePullPolicy: IfNotPresent
           args:
             - config-generator
@@ -346,7 +346,7 @@ spec:
             - mountPath: /etc/secret-volume
               name: tezos-accounts        
         - name: snapshot-downloader
-          image: "ghcr.io/oxheadalpha/tezos-k8s-utils:latest"
+          image: "ghcr.io/oxheadalpha/tezos-k8s-utils:master"
           imagePullPolicy: IfNotPresent
           args:
             - snapshot-downloader
@@ -558,7 +558,7 @@ spec:
               path: /is_synced
               port: 31732                                
         - name: logger
-          image: "ghcr.io/oxheadalpha/tezos-k8s-utils:latest"
+          image: "ghcr.io/oxheadalpha/tezos-k8s-utils:master"
           imagePullPolicy: IfNotPresent
           args:
             - logger
@@ -588,7 +588,7 @@ spec:
             - mountPath: /var/tezos
               name: var-volume                
         - name: sidecar
-          image: "ghcr.io/oxheadalpha/tezos-k8s-utils:latest"
+          image: "ghcr.io/oxheadalpha/tezos-k8s-utils:master"
           imagePullPolicy: IfNotPresent
           args:
             - sidecar
@@ -667,7 +667,7 @@ spec:
             - mountPath: /var/tezos
               name: var-volume                
         - name: config-generator
-          image: "ghcr.io/oxheadalpha/tezos-k8s-utils:latest"
+          image: "ghcr.io/oxheadalpha/tezos-k8s-utils:master"
           imagePullPolicy: IfNotPresent
           args:
             - config-generator
@@ -699,7 +699,7 @@ spec:
             - mountPath: /etc/secret-volume
               name: tezos-accounts        
         - name: snapshot-downloader
-          image: "ghcr.io/oxheadalpha/tezos-k8s-utils:latest"
+          image: "ghcr.io/oxheadalpha/tezos-k8s-utils:master"
           imagePullPolicy: IfNotPresent
           args:
             - snapshot-downloader

--- a/test/charts/private-chain.expect.yaml
+++ b/test/charts/private-chain.expect.yaml
@@ -415,7 +415,7 @@ spec:
             - mountPath: /etc/tezos/per-block-votes
               name: per-block-votes        
         - name: logger
-          image: "ghcr.io/oxheadalpha/tezos-k8s-utils:latest"
+          image: "ghcr.io/oxheadalpha/tezos-k8s-utils:master"
           imagePullPolicy: IfNotPresent
           args:
             - logger
@@ -443,7 +443,7 @@ spec:
             - mountPath: /var/tezos
               name: var-volume                
         - name: sidecar
-          image: "ghcr.io/oxheadalpha/tezos-k8s-utils:latest"
+          image: "ghcr.io/oxheadalpha/tezos-k8s-utils:master"
           imagePullPolicy: IfNotPresent
           args:
             - sidecar
@@ -472,7 +472,7 @@ spec:
               name: var-volume        
       initContainers:                        
         - name: config-generator
-          image: "ghcr.io/oxheadalpha/tezos-k8s-utils:latest"
+          image: "ghcr.io/oxheadalpha/tezos-k8s-utils:master"
           imagePullPolicy: IfNotPresent
           args:
             - config-generator
@@ -502,7 +502,7 @@ spec:
             - mountPath: /etc/secret-volume
               name: tezos-accounts                        
         - name: wait-for-dns
-          image: "ghcr.io/oxheadalpha/tezos-k8s-utils:latest"
+          image: "ghcr.io/oxheadalpha/tezos-k8s-utils:master"
           imagePullPolicy: IfNotPresent
           args:
             - wait-for-dns
@@ -640,7 +640,7 @@ spec:
               path: /is_synced
               port: 31732                                                
         - name: sidecar
-          image: "ghcr.io/oxheadalpha/tezos-k8s-utils:latest"
+          image: "ghcr.io/oxheadalpha/tezos-k8s-utils:master"
           imagePullPolicy: IfNotPresent
           args:
             - sidecar
@@ -669,7 +669,7 @@ spec:
               name: var-volume        
       initContainers:                        
         - name: config-generator
-          image: "ghcr.io/oxheadalpha/tezos-k8s-utils:latest"
+          image: "ghcr.io/oxheadalpha/tezos-k8s-utils:master"
           imagePullPolicy: IfNotPresent
           args:
             - config-generator
@@ -699,7 +699,7 @@ spec:
             - mountPath: /etc/secret-volume
               name: tezos-accounts                        
         - name: wait-for-dns
-          image: "ghcr.io/oxheadalpha/tezos-k8s-utils:latest"
+          image: "ghcr.io/oxheadalpha/tezos-k8s-utils:master"
           imagePullPolicy: IfNotPresent
           args:
             - wait-for-dns
@@ -902,7 +902,7 @@ spec:
             - mountPath: /etc/tezos/per-block-votes
               name: per-block-votes        
         - name: logger
-          image: "ghcr.io/oxheadalpha/tezos-k8s-utils:latest"
+          image: "ghcr.io/oxheadalpha/tezos-k8s-utils:master"
           imagePullPolicy: IfNotPresent
           args:
             - logger
@@ -930,7 +930,7 @@ spec:
             - mountPath: /var/tezos
               name: var-volume                
         - name: sidecar
-          image: "ghcr.io/oxheadalpha/tezos-k8s-utils:latest"
+          image: "ghcr.io/oxheadalpha/tezos-k8s-utils:master"
           imagePullPolicy: IfNotPresent
           args:
             - sidecar
@@ -959,7 +959,7 @@ spec:
               name: var-volume        
       initContainers:                        
         - name: config-generator
-          image: "ghcr.io/oxheadalpha/tezos-k8s-utils:latest"
+          image: "ghcr.io/oxheadalpha/tezos-k8s-utils:master"
           imagePullPolicy: IfNotPresent
           args:
             - config-generator
@@ -989,7 +989,7 @@ spec:
             - mountPath: /etc/secret-volume
               name: tezos-accounts                        
         - name: wait-for-dns
-          image: "ghcr.io/oxheadalpha/tezos-k8s-utils:latest"
+          image: "ghcr.io/oxheadalpha/tezos-k8s-utils:master"
           imagePullPolicy: IfNotPresent
           args:
             - wait-for-dns
@@ -1191,7 +1191,7 @@ spec:
             - mountPath: /etc/tezos/per-block-votes
               name: per-block-votes                        
         - name: sidecar
-          image: "ghcr.io/oxheadalpha/tezos-k8s-utils:latest"
+          image: "ghcr.io/oxheadalpha/tezos-k8s-utils:master"
           imagePullPolicy: IfNotPresent
           args:
             - sidecar
@@ -1220,7 +1220,7 @@ spec:
               name: var-volume        
       initContainers:                        
         - name: config-generator
-          image: "ghcr.io/oxheadalpha/tezos-k8s-utils:latest"
+          image: "ghcr.io/oxheadalpha/tezos-k8s-utils:master"
           imagePullPolicy: IfNotPresent
           args:
             - config-generator
@@ -1250,7 +1250,7 @@ spec:
             - mountPath: /etc/secret-volume
               name: tezos-accounts                        
         - name: wait-for-dns
-          image: "ghcr.io/oxheadalpha/tezos-k8s-utils:latest"
+          image: "ghcr.io/oxheadalpha/tezos-k8s-utils:master"
           imagePullPolicy: IfNotPresent
           args:
             - wait-for-dns
@@ -1365,7 +1365,7 @@ spec:
             exec $CMD
             
       initContainers:
-      - image: ghcr.io/oxheadalpha/tezos-k8s-utils:latest
+      - image: ghcr.io/oxheadalpha/tezos-k8s-utils:master
         imagePullPolicy: IfNotPresent
         name: config-generator
         args:
@@ -1445,7 +1445,7 @@ spec:
             - mountPath: /var/tezos
               name: var-volume
       initContainers:
-        - image: ghcr.io/oxheadalpha/tezos-k8s-utils:latest
+        - image: ghcr.io/oxheadalpha/tezos-k8s-utils:master
           imagePullPolicy: IfNotPresent
           name: config-generator
           args:


### PR DESCRIPTION
https://github.com/oxheadalpha/tezos-k8s/pull/504#issuecomment-1309538319
> Shouldn't the tag be master and not latest? The current latest image in the registry is 6.11.1. The image could become out of date when master is updated but doesn't become latest tag. Like it is right now.
> 
> So if i pull master, the image could be wrong and not reflect what the code actually is on master.

