### PR TITLE
Set node config for pods without dedicated instance configs

### DIFF
--- a/utils/config-generator.py
+++ b/utils/config-generator.py
@@ -43,6 +43,13 @@ for cl, val in NODES.items():
                 if "baker" in val["runs"]:
                     BAKING_NODES[name] = inst
 
+# MY_POD_CLASS is not set after iterating nodes configurations,
+# this can happen when the pod is one which scaled out by autoscaler.
+# Set this value to the value mapped by MY_NODE_CLASS to read possible config specified in at NODES
+if not MY_POD_CLASS:
+    my_node_class = os.environ["MY_NODE_CLASS"]
+    MY_POD_CLASS = NODES[my_node_class]
+
 if MY_POD_TYPE == "signing":
     MY_POD_CONFIG = SIGNERS[MY_POD_NAME]
 


### PR DESCRIPTION
This is a duplicated one of PR #500 , generated from a branch in official repo for all the CI checks to be run

In combination with a horizontal pod autoscaler (not supported in tezos-k8s yet), this will ensure that any additional replicas spun up by the autoscaler will also be configured according to the statefulset-level config in values.yaml (and node_globals as well)