### PR TITLE
Add reources management for nodes

### DIFF
--- a/charts/tezos/templates/_containers.tpl
+++ b/charts/tezos/templates/_containers.tpl
@@ -43,6 +43,8 @@
      *    with_config    bring in the configMap defaults true only on utils.
      *    with_secret    bring in the secrets map including the identities.
      *    localvars      set env vars MY_* Defaults to true only on utils.
+     *    resources      set container resources management, i.e. request
+     *                   and limit, default value is an empty dict.
      */ -}}
 
 {{- define "tezos.generic_container" }}
@@ -74,6 +76,9 @@
   {{- if eq .image "utils" }}
     {{- $_ := set . "args" (list .type) }}
   {{- end }}
+{{- end }}
+{{- if not (hasKey . "resources") }}
+    {{- $_ := set . "resources" dict }}
 {{- end }}
 
 {{- /*
@@ -164,6 +169,10 @@
       port: 31732
     {{- end }}
   {{- end }}
+{{- if .resources }}
+  resources:
+{{ toYaml .resources | indent 4 }}
+{{- end }}
 {{- end }}
 
 
@@ -237,9 +246,11 @@
 
 {{- define "tezos.container.sidecar" }}
   {{- if or (not (hasKey $.node_vals "readiness_probe")) $.node_vals.readiness_probe }}
-    {{- include "tezos.generic_container" (dict "root"  $
-                                                "type"  "sidecar"
-                                                "image" "utils"
+    {{- $sidecarResources := dict "requests" (dict "memory" "80Mi") "limits" (dict "memory" "100Mi") -}}
+    {{- include "tezos.generic_container" (dict "root"      $
+                                                "type"      "sidecar"
+                                                "image"     "utils"
+                                                "resources" $sidecarResources
     ) | nindent 0 }}
   {{- end }}
 {{- end }}
@@ -249,6 +260,7 @@
                                                 "type"        "octez-node"
                                                 "image"       "octez"
                                                 "with_config" 0
+                                                "resources"   $.node_vals.resources
     ) | nindent 0 }}
 {{- end }}
 

--- a/charts/tezos/values.yaml
+++ b/charts/tezos/values.yaml
@@ -114,6 +114,8 @@ should_generate_unsafe_deterministic_data: false
 #          using just "baker".
 # - "storage_size": the size of the PV
 # - "resources": resources specifications for the node.
+#                Optionally set resources and limits for octez node
+#                See: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 # - "images": Optional specification of images to use for the tezos node and
 #           baker. Options are "octez" with a tezos/tezos image.
 #           If no images are provided, the containers will default to the images
@@ -188,8 +190,6 @@ should_generate_unsafe_deterministic_data: false
 #     runs:
 #       - octez_node
 #       - baker
-#     # You can optionally set resources and limits for your octez node
-#     # See: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 #     resources:
 #       requests:
 #         memory: 16192Mi

--- a/charts/tezos/values.yaml
+++ b/charts/tezos/values.yaml
@@ -113,6 +113,7 @@ should_generate_unsafe_deterministic_data: false
 #          bakers and accusers, so "baker-011-pthangz2" is configured
 #          using just "baker".
 # - "storage_size": the size of the PV
+# - "resources": resources specifications for the node.
 # - "images": Optional specification of images to use for the tezos node and
 #           baker. Options are "octez" with a tezos/tezos image.
 #           If no images are provided, the containers will default to the images
@@ -187,6 +188,13 @@ should_generate_unsafe_deterministic_data: false
 #     runs:
 #       - octez_node
 #       - baker
+#     # You can optionally set resources and limits for your octez node/baker
+#     # See: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+#     resources:
+#       requests:
+#         memory: 16192Mi
+#       limits:
+#         memory: 16192Mi
 #     instances:
 #       - bake_using_account: baker0
 #         is_bootstrap_node: true

--- a/charts/tezos/values.yaml
+++ b/charts/tezos/values.yaml
@@ -188,7 +188,7 @@ should_generate_unsafe_deterministic_data: false
 #     runs:
 #       - octez_node
 #       - baker
-#     # You can optionally set resources and limits for your octez node/baker
+#     # You can optionally set resources and limits for your octez node
 #     # See: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 #     resources:
 #       requests:

--- a/test/charts/mainnet.expect.yaml
+++ b/test/charts/mainnet.expect.yaml
@@ -198,7 +198,12 @@ spec:
             - mountPath: /etc/tezos
               name: config-volume
             - mountPath: /var/tezos
-              name: var-volume        
+              name: var-volume
+          resources:
+            limits:
+              memory: 100Mi
+            requests:
+              memory: 80Mi        
       initContainers:        
         - name: config-init
           image: "tezos/tezos:v15-release"

--- a/test/charts/mainnet2.expect.yaml
+++ b/test/charts/mainnet2.expect.yaml
@@ -90,6 +90,14 @@ data:
             }
           }
         ],
+        "resources": {
+          "limits": {
+            "memory": "16192Mi"
+          },
+          "requests": {
+            "memory": "16192Mi"
+          }
+        },
         "runs": [
           "octez_node",
           "logger",
@@ -293,7 +301,12 @@ spec:
             - mountPath: /etc/tezos
               name: config-volume
             - mountPath: /var/tezos
-              name: var-volume        
+              name: var-volume
+          resources:
+            limits:
+              memory: 100Mi
+            requests:
+              memory: 80Mi        
       initContainers:        
         - name: config-init
           image: "tezos/tezos:v15-release"
@@ -586,7 +599,12 @@ spec:
           readinessProbe:
             httpGet:
               path: /is_synced
-              port: 31732                        
+              port: 31732
+          resources:
+            limits:
+              memory: 16192Mi
+            requests:
+              memory: 16192Mi                        
         - name: logger
           image: "ghcr.io/oxheadalpha/tezos-k8s-utils:master"
           imagePullPolicy: IfNotPresent
@@ -646,7 +664,12 @@ spec:
             - mountPath: /etc/tezos
               name: config-volume
             - mountPath: /var/tezos
-              name: var-volume        
+              name: var-volume
+          resources:
+            limits:
+              memory: 100Mi
+            requests:
+              memory: 80Mi        
       initContainers:        
         - name: config-init
           image: "tezos/tezos:v15-release"

--- a/test/charts/mainnet2.in.yaml
+++ b/test/charts/mainnet2.in.yaml
@@ -16,6 +16,11 @@ nodes:
     images:
       octez: tezos/tezos:v15-release
     runs: [ octez_node, logger, metrics ]
+    resources:
+      requests:
+        memory: 16192Mi
+      limits:
+        memory: 16192Mi
     instances:
     - config:
         shell: {history_mode: rolling}

--- a/test/charts/private-chain.expect.yaml
+++ b/test/charts/private-chain.expect.yaml
@@ -375,7 +375,12 @@ spec:
             - mountPath: /etc/tezos
               name: config-volume
             - mountPath: /var/tezos
-              name: var-volume        
+              name: var-volume
+          resources:
+            limits:
+              memory: 100Mi
+            requests:
+              memory: 80Mi        
       initContainers:                        
         - name: config-generator
           image: "ghcr.io/oxheadalpha/tezos-k8s-utils:master"
@@ -665,7 +670,12 @@ spec:
             - mountPath: /etc/tezos
               name: config-volume
             - mountPath: /var/tezos
-              name: var-volume        
+              name: var-volume
+          resources:
+            limits:
+              memory: 100Mi
+            requests:
+              memory: 80Mi        
       initContainers:                        
         - name: config-generator
           image: "ghcr.io/oxheadalpha/tezos-k8s-utils:master"
@@ -926,7 +936,12 @@ spec:
             - mountPath: /etc/tezos
               name: config-volume
             - mountPath: /var/tezos
-              name: var-volume        
+              name: var-volume
+          resources:
+            limits:
+              memory: 100Mi
+            requests:
+              memory: 80Mi        
       initContainers:                        
         - name: config-generator
           image: "ghcr.io/oxheadalpha/tezos-k8s-utils:master"


### PR DESCRIPTION
This is a duplicated one of #502, PR generated from official repo branch to run all the CI jobs

This PR would set the resource manage for octez nodes and sidecar in the same pod. For bakers, there are no resources management for it however

Users can manage the node resources for octez node placement. Additionally, users can use k8s autoscalers to scale out node pods based on certain criteria
https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale
This scaling mechanism is for pod, so both octez node and sidecar resources should be specified for the pod resource usage to be calculated. For now, pods with bakers running inside is not supported.