### PR TITLE
Multiple baker processes

### DIFF
--- a/charts/tezos/scripts/baker.sh
+++ b/charts/tezos/scripts/baker.sh
@@ -28,8 +28,6 @@ if [[ "$tezos_version" == *"13.0"* ]]; then
   extra_args="$extra_args --liquidity-baking-toggle-vote on"
 fi
 
-my_baker_account="$(cat /etc/tezos/baker-account )"
-
 CLIENT="$TEZ_BIN/tezos-client -d $CLIENT_DIR"
 CMD="$TEZ_BIN/tezos-baker-$proto_command -d $CLIENT_DIR"
 
@@ -40,4 +38,4 @@ while ! $CLIENT rpc get chains/main/blocks/head; do
     sleep 5
 done
 
-exec $CMD run with local node $NODE_DATA_DIR ${extra_args} ${BAKER_EXTRA_ARGS_FROM_ENV} ${my_baker_account}
+exec $CMD run with local node $NODE_DATA_DIR ${extra_args} ${BAKER_EXTRA_ARGS_FROM_ENV} ${BAKING_ACCOUNT}

--- a/charts/tezos/templates/_containers.tpl
+++ b/charts/tezos/templates/_containers.tpl
@@ -121,6 +121,10 @@
   {{- if .localvars }}
   {{- include "tezos.localvars.pod_envvars" $ | indent 4 }}
   {{- end }}
+  {{- if .baking_account }}
+    - name: BAKING_ACCOUNT
+      value: {{ .baking_account}}
+  {{- end }}
     - name: DAEMON
       value: {{ .type }}
 {{- $envdict := dict }}
@@ -286,8 +290,8 @@
 {{- define "tezos.container.bakers" }}
   {{- if has "baker" $.node_vals.runs }}
     {{- $node_vals_images := $.node_vals.images | default dict }}
-    {{- $baking_accounts := (first $.node_vals.instances).bake_using_accounts }}
-    {{- range $baking_accounts }}
+    {{- range (first $.node_vals.instances).bake_using_accounts }}
+      {{- $baking_account := . }}
       # note, if several instances of the same statefulset have a different number of bakers,
       # the chart is invalid.
       {{- range $.Values.protocols }}
@@ -297,9 +301,11 @@
         {{- $_ := set $ "command_in_tpl" .command }}
         {{- include "tezos.generic_container" (dict "root" $
                                                     "name" (print "baker-"
-                                                            (lower .command))
+                                                            (lower .command)
+                                                            (print $baking_account))
                                                     "type"        "baker"
                                                     "image"       "octez"
+                                                    "baking_account" (print $baking_account)
         ) | nindent 0 }}
       {{- end }}
     {{- end }}

--- a/charts/tezos/templates/_containers.tpl
+++ b/charts/tezos/templates/_containers.tpl
@@ -286,17 +286,21 @@
 {{- define "tezos.container.bakers" }}
   {{- if has "baker" $.node_vals.runs }}
     {{- $node_vals_images := $.node_vals.images | default dict }}
-    {{- range .Values.protocols }}
-      {{- if (not .vote) }}
-        {{ fail (print "You did not specify the liquidity baking toggle vote in 'protocols' for protocol " .command ".") }}
-      {{- end -}}
-      {{- $_ := set $ "command_in_tpl" .command }}
-      {{- include "tezos.generic_container" (dict "root" $
-                                                  "name" (print "baker-"
-                                                          (lower .command))
-                                                  "type"        "baker"
-                                                  "image"       "octez"
-      ) | nindent 0 }}
+    {{- range (first $.node_vals.instances).bake_using_accounts }}
+      # note, if several instances of the same statefulset have a different number of bakers,
+      # the chart is invalid.
+      {{- range $.Values.protocols }}
+        {{- if (not .vote) }}
+          {{ fail (print "You did not specify the liquidity baking toggle vote in 'protocols' for protocol " .command ".") }}
+        {{- end -}}
+        {{- $_ := set $ "command_in_tpl" .command }}
+        {{- include "tezos.generic_container" (dict "root" $
+                                                    "name" (print "baker-"
+                                                            (lower .command))
+                                                    "type"        "baker"
+                                                    "image"       "octez"
+        ) | nindent 0 }}
+      {{- end }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/tezos/templates/_containers.tpl
+++ b/charts/tezos/templates/_containers.tpl
@@ -286,7 +286,8 @@
 {{- define "tezos.container.bakers" }}
   {{- if has "baker" $.node_vals.runs }}
     {{- $node_vals_images := $.node_vals.images | default dict }}
-    {{- range (first $.node_vals.instances).bake_using_accounts }}
+    {{- $baking_accounts := (first $.node_vals.instances).bake_using_accounts }}
+    {{- range $baking_accounts }}
       # note, if several instances of the same statefulset have a different number of bakers,
       # the chart is invalid.
       {{- range $.Values.protocols }}

--- a/utils/config-generator.sh
+++ b/utils/config-generator.sh
@@ -39,33 +39,3 @@ EOM
 < /etc/tezos/config.json jq -r '.p2p."bootstrap-peers"[]'	| \
 	tr '\012' ',' | sed s/^/--bootstrap-lookup-address=/	  \
 		>> /etc/tezos/tezedge.conf
-
-#
-# Next we write the current baker account into /etc/tezos/baking-account.
-# We do it here because we shall use jq to process some of the environment
-# variables and we are not guaranteed to have jq available on an arbitrary
-# tezos docker image.
-
-MY_CLASS=$(echo $NODES | jq -r ".\"${MY_NODE_CLASS}\"")
-AM_I_BAKER=0
-if [ "$MY_CLASS" != null ]; then
-    AM_I_BAKER=$(echo $MY_CLASS | \
-		 jq -r '.runs|map(select(. == "baker"))|length')
-fi
-
-if [ "$AM_I_BAKER" -eq 1 ]; then
-    my_baker_account=$(echo $MY_CLASS | \
-	    jq -r ".instances[${MY_POD_NAME#$MY_NODE_CLASS-}]
-		   |if .bake_using_accounts
-		    then .bake_using_accounts[]
-		    else .bake_using_account
-		    end")
-
-    # If no account to bake for was specified in the node's settings,
-    # config-generator defaults the account name to the pod's name.
-    if [ "$my_baker_account" = null ]; then
-	my_baker_account="$MY_POD_NAME"
-    fi
-
-    echo "$my_baker_account" > /etc/tezos/baker-account
-fi


### PR DESCRIPTION
When baking for several addresses, it's recommended to spin up several baking processes.

Otherwise, baking is sequential and can be too slow, especially in combination with remote signers.

This PR switches to one baking process per baker.

There are problems: how many processes do we start? There has to be a constant number per statefulset.

The most sensible thing seems to be to lock the replica count of any baking statefulset to one?

Or enforce a constant number of bakers for all members of the statefulset within helm? I'm open to suggestions here.

There is a mechanism from @elric1 to guess the baking account when it's not specified. Since this change likely breaks it, I removed it.