### PR TITLE
remove traces of tezedge

### DIFF
--- a/charts/tezos/templates/_containers.tpl
+++ b/charts/tezos/templates/_containers.tpl
@@ -83,7 +83,7 @@
 {{- $node_vals_images := $.node_vals.images | default dict }}
 {{- if eq .image "octez" }}
   image: "{{ or $node_vals_images.octez $.Values.images.octez }}"
-{{- else if eq .image "utils" }}
+{{- else }}
   image: "{{ $.Values.tezos_k8s_images.utils }}"
 {{- end }}
   imagePullPolicy: IfNotPresent

--- a/charts/tezos/templates/nodes.yaml
+++ b/charts/tezos/templates/nodes.yaml
@@ -32,7 +32,6 @@ spec:
     spec:
       containers:
         {{- include "tezos.container.node"      $ | indent 8 }}
-        {{- include "tezos.container.tezedge"   $ | indent 8 }}
         {{- include "tezos.container.accusers"  $ | indent 8 }}
         {{- include "tezos.container.bakers"    $ | indent 8 }}
         {{- include "tezos.container.logger"    $ | indent 8 }}

--- a/charts/tezos/values.yaml
+++ b/charts/tezos/values.yaml
@@ -9,7 +9,6 @@ is_invitation: false
 # Images not part of the tezos-k8s repo go here
 images:
   octez: tezos/tezos:v14-release
-  tezedge: tezedge/tezedge:v1.6.8
 # Images that are part of the tezos-k8s repo go here with 'dev' tag
 tezos_k8s_images:
   utils: ghcr.io/oxheadalpha/tezos-k8s-utils:master
@@ -115,13 +114,11 @@ should_generate_unsafe_deterministic_data: false
 #          using just "baker".
 # - "storage_size": the size of the PV
 # - "images": Optional specification of images to use for the tezos node and
-#           baker. Options are "octez" with a tezos/tezos image or
-#           "tezedge" with a tezedge/tezedge image. If no images are provided,
-#           the containers will default to the images defined in the "images"
-#           field up above.
-# - "runs": A list of containers to run. A tezos node implementation is required.
-#         Options being "octez_node" or "tezedge_node". Other optional
-#         containers are "accuser", "baker", "logger" and "vdf".
+#           baker. Options are "octez" with a tezos/tezos image.
+#           If no images are provided, the containers will default to the images
+#           defined in the "images" field up above.
+# - "runs": A list of containers to run.
+#         Options being "octez_node", "accuser", "baker", "logger" and "vdf".
 # - "local_storage": use local storage instead of a volume. The storage will be
 #                  wiped when the node restarts for any reason. Useful when
 #                  faster IO is desired. Defaults to false.
@@ -186,11 +183,9 @@ should_generate_unsafe_deterministic_data: false
 #     storage_size: 15Gi
 #     images: # (optional field)
 #       octez: tezos/tezos:v...
-#     # tezedge: tezedge/tezedg:v...
 #     local_storage: false
 #     runs:
 #       - octez_node
-#     # - tezedge_node
 #       - baker
 #     instances:
 #       - bake_using_account: baker0
@@ -211,8 +206,8 @@ should_generate_unsafe_deterministic_data: false
 #       peer_node: "true"
 #       rpc_node: "true"
 #     images: # (optional field)
-#       tezedge: tezedge/tezedge:v...
-#     runs: ["tezedge_node"]
+#       octez: tezos/tezos:v...
+#     runs: ["octez_node"]
 #     instances:
 #       - {}
 #       - {}

--- a/docs/Private-Chain.md
+++ b/docs/Private-Chain.md
@@ -109,7 +109,7 @@ Said names are traditionally kebab case.
 At the statefulset level, the following parameters are allowed:
 
    - storage_size: the size of the PV
-   - runs: a list of containers to run, e.g. "baker", "tezedge"
+   - runs: a list of containers to run, e.g. "baker", "accuser"
    - instances: a list of nodes to fire up, each is a dictionary
      defining:
      - `bake_using_account`: The name of the account that should be used
@@ -120,11 +120,6 @@ At the statefulset level, the following parameters are allowed:
                Run `tezos-node config --help` for more info.
 
 defaults are filled in for most values.
-
-Each statefulset can run either Nomadic Lab's `tezos-node` or TezEdge's
-`tezedge` node.  Either can support all of the other containers.  If you
-specify `tezedge` as one of the containers to run, then it will be run
-in preference to `tezos-node`.
 
 E.g.:
 
@@ -145,29 +140,16 @@ nodes:
     instances:
       - {}
       - {}
-  tezedge-full-node:
-    runs:
-      - baker
-      - logger
-      - tezedge
-    instances:
-      - {}
-      - {}
-      - {}
 ```
 
 This will run the following nodes:
    - `baking-node-0`
    - `full-node-0`
    - `full-node-1`
-   - `tezedge-full-node-0`
-   - `tezedge-full-node-1`
-   - `tezedge-full-node-2`
 
 `baking-node-0` will run baker and logger containers
 and will be the only bootstrap node.  `full-node-*` are just nodes
-with no extras.  `tezedge-full-node-*` will be tezedge nodes running baker
-and logger containers.
+with no extras. 
 
 To upgrade your Helm release run:
 

--- a/test/charts/mainnet.expect.yaml
+++ b/test/charts/mainnet.expect.yaml
@@ -168,7 +168,7 @@ spec:
           readinessProbe:
             httpGet:
               path: /is_synced
-              port: 31732                                                
+              port: 31732                                        
         - name: sidecar
           image: "ghcr.io/oxheadalpha/tezos-k8s-utils:master"
           imagePullPolicy: IfNotPresent

--- a/test/charts/mainnet2.expect.yaml
+++ b/test/charts/mainnet2.expect.yaml
@@ -174,18 +174,44 @@ spec:
         appType: tezos-node
         node_class: city-block
     spec:
-      containers:                
-        - name: tezedge-node
-          image: "tezedge/tezedge:v1.6.8"
+      containers:        
+        - name: octez-node
+          image: "tezos/tezos:v14-release"
           imagePullPolicy: IfNotPresent
           command:
-            - /light-node
+            - /bin/sh
           args:
-            - --config-file=/etc/tezos/tezedge.conf
+            - "-c"
+            - |
+              set -x
+              
+              set
+              
+              # ensure we can run tezos-client commands without specifying client dir
+              ln -s /var/tezos/client /home/tezos/.tezos-client
+              #
+              # Not every error is fatal on start.  In particular, with zerotier,
+              # the listen-addr may not yet be bound causing tezos-node to fail.
+              # So, we try a few times with increasing delays:
+              
+              for d in 1 1 5 10 20 60 120; do
+              	/usr/local/bin/tezos-node run				\
+              			--bootstrap-threshold 0			\
+              			--config-file /etc/tezos/config.json
+              	sleep $d
+              done
+              
+              #
+              # Keep the container alive for troubleshooting on failures:
+              
+              sleep 3600
+              
           envFrom:
           env:
             - name: DAEMON
-              value: tezedge-node
+              value: octez-node
+            - name:  TEZOS_LOG
+              value: "* -> DEBUG"
             - name:  key
               value: "outer-value"
           volumeMounts:
@@ -556,7 +582,7 @@ spec:
           readinessProbe:
             httpGet:
               path: /is_synced
-              port: 31732                                
+              port: 31732                        
         - name: logger
           image: "ghcr.io/oxheadalpha/tezos-k8s-utils:master"
           imagePullPolicy: IfNotPresent

--- a/test/charts/private-chain.expect.yaml
+++ b/test/charts/private-chain.expect.yaml
@@ -323,18 +323,42 @@ spec:
         node_class: af
         baking_node: "true"
     spec:
-      containers:                
-        - name: tezedge-node
-          image: "tezedge/tezedge:v1.6.8"
+      containers:        
+        - name: octez-node
+          image: "tezos/tezos:v14-release"
           imagePullPolicy: IfNotPresent
           command:
-            - /light-node
+            - /bin/sh
           args:
-            - --config-file=/etc/tezos/tezedge.conf
+            - "-c"
+            - |
+              set -x
+              
+              set
+              
+              # ensure we can run tezos-client commands without specifying client dir
+              ln -s /var/tezos/client /home/tezos/.tezos-client
+              #
+              # Not every error is fatal on start.  In particular, with zerotier,
+              # the listen-addr may not yet be bound causing tezos-node to fail.
+              # So, we try a few times with increasing delays:
+              
+              for d in 1 1 5 10 20 60 120; do
+              	/usr/local/bin/tezos-node run				\
+              			--bootstrap-threshold 0			\
+              			--config-file /etc/tezos/config.json
+              	sleep $d
+              done
+              
+              #
+              # Keep the container alive for troubleshooting on failures:
+              
+              sleep 3600
+              
           envFrom:
           env:
             - name: DAEMON
-              value: tezedge-node
+              value: octez-node
           volumeMounts:
             - mountPath: /etc/tezos
               name: config-volume
@@ -638,7 +662,7 @@ spec:
           readinessProbe:
             httpGet:
               path: /is_synced
-              port: 31732                                                
+              port: 31732                                        
         - name: sidecar
           image: "ghcr.io/oxheadalpha/tezos-k8s-utils:master"
           imagePullPolicy: IfNotPresent
@@ -837,7 +861,7 @@ spec:
           readinessProbe:
             httpGet:
               path: /is_synced
-              port: 31732                        
+              port: 31732                
         - name: baker-013-ptjakart
           image: "tezos/tezos:v14-release"
           imagePullPolicy: IfNotPresent
@@ -1126,7 +1150,7 @@ spec:
           readinessProbe:
             httpGet:
               path: /is_synced
-              port: 31732                        
+              port: 31732                
         - name: baker-013-ptjakart
           image: "tezos/tezos:v14-release"
           imagePullPolicy: IfNotPresent

--- a/utils/config-generator.sh
+++ b/utils/config-generator.sh
@@ -10,36 +10,6 @@ chmod -R 777 /var/tezos
 set -e
 python3 /config-generator.py "$@"
 set +e
-
-#
-# Generate the tezedge configuration file:
-
-cat > /etc/tezos/tezedge.conf <<EOM
---network=custom
---custom-network-file=/etc/tezos/config.json
---p2p-port=9732
---rpc-port=8732
---init-sapling-spend-params-file=/sapling-spend.params
---init-sapling-output-params-file=/sapling-output.params
---tezos-data-dir=/var/tezos/node/data
---bootstrap-db-path=/var/tezos/node/bootstrap
---identity-file=/tmp/tezedge/identity.json
---identity-expected-pow=0
---log-format=simple
---log-level=info
---ocaml-log-enabled=false
---peer-thresh-low=10
---peer-thresh-high=15
---protocol-runner=/protocol-runner
---tokio-threads=0
---enable-testchain=false
---log=terminal
-EOM
-
-< /etc/tezos/config.json jq -r '.p2p."bootstrap-peers"[]'	| \
-	tr '\012' ',' | sed s/^/--bootstrap-lookup-address=/	  \
-		>> /etc/tezos/tezedge.conf
-
 #
 # Next we write the current baker account into /etc/tezos/baking-account.
 # We do it here because we shall use jq to process some of the environment


### PR DESCRIPTION
Tezedge has been deprecated, removing this option from tezos-k8s.