### PR TITLE
TRD mainnet adaptations

### DIFF
--- a/charts/tezos-reward-distributor/scripts/bucket_upload.sh
+++ b/charts/tezos-reward-distributor/scripts/bucket_upload.sh
@@ -2,8 +2,8 @@
 
 echo "Uploading TRD data to bucket"
 
+source /trd/config/bucket_upload_secrets
 if [ ! -z ${BUCKET_NAME} ];then
-    export AWS_SECRET_ACCESS_KEY=$(cat /trd/config/aws_secret_access_key)
     aws s3  cp --recursive  /trd/ s3://${BUCKET_NAME}/${BAKER_NAME} --endpoint $BUCKET_ENDPOINT_URL
 fi
 sleep 10

--- a/charts/tezos-reward-distributor/scripts/bucket_upload.sh
+++ b/charts/tezos-reward-distributor/scripts/bucket_upload.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+echo "Would upload bucket here"
+echo "AWS_ACCESS_KEY_ID"
+echo "$AWS_ACCESS_KEY_ID"
+echo "AWS_SECRET_ACCESS_KEY"
+echo "$AWS_SECRET_ACCESS_KEY"
+sleep 10

--- a/charts/tezos-reward-distributor/scripts/bucket_upload.sh
+++ b/charts/tezos-reward-distributor/scripts/bucket_upload.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
-echo "Would upload bucket here"
-echo "AWS_ACCESS_KEY_ID"
-echo "$AWS_ACCESS_KEY_ID"
-echo "AWS_SECRET_ACCESS_KEY"
-echo "$AWS_SECRET_ACCESS_KEY"
+echo "Uploading TRD data to bucket"
+
+if [ ! -z ${BUCKET_NAME} ];then
+    aws s3  cp --recursive  /trd/ s3://${BUCKET_NAME}/${BAKER_NAME} --endpoint $BUCKET_ENDPOINT_URL
+fi
 sleep 10

--- a/charts/tezos-reward-distributor/scripts/bucket_upload.sh
+++ b/charts/tezos-reward-distributor/scripts/bucket_upload.sh
@@ -2,7 +2,7 @@
 
 echo "Uploading TRD data to bucket"
 
-source /trd/config/bucket_upload_secrets
+source /trd/cfg/bucket_upload_secrets
 if [ ! -z ${BUCKET_NAME} ];then
     aws s3  cp --recursive  /trd/ s3://${BUCKET_NAME}/${BAKER_NAME} --endpoint $BUCKET_ENDPOINT_URL
 fi

--- a/charts/tezos-reward-distributor/scripts/bucket_upload.sh
+++ b/charts/tezos-reward-distributor/scripts/bucket_upload.sh
@@ -3,6 +3,7 @@
 echo "Uploading TRD data to bucket"
 
 if [ ! -z ${BUCKET_NAME} ];then
+    export AWS_SECRET_ACCESS_KEY=$(cat /trd/config/aws_secret_access_key)
     aws s3  cp --recursive  /trd/ s3://${BUCKET_NAME}/${BAKER_NAME} --endpoint $BUCKET_ENDPOINT_URL
 fi
 sleep 10

--- a/charts/tezos-reward-distributor/scripts/bucket_upload_secrets
+++ b/charts/tezos-reward-distributor/scripts/bucket_upload_secrets
@@ -1,0 +1,3 @@
+export AWS_ACCESS_KEY_ID="{{ .Values.bucket_upload_secrets.access_key_id }}"
+export AWS_SECRET_ACCESS_KEY="{{ .Values.bucket_upload_secrets.secret_access_key }}"
+export AWS_DEFAULT_REGION="{{ .Values.bucket_upload_secrets.default_region }}"

--- a/charts/tezos-reward-distributor/scripts/run.sh
+++ b/charts/tezos-reward-distributor/scripts/run.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if [ "${DRY_RUN}" == "false"]; then
+if [ "${DRY_RUN}" == "false" ]; then
   dry_run_arg=""
 else
   dry_run_arg="--dry_run"

--- a/charts/tezos-reward-distributor/scripts/run.sh
+++ b/charts/tezos-reward-distributor/scripts/run.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+if [ "${DRY_RUN}" == "false"]; then
+  dry_run_arg=""
+else
+  dry_run_arg="--dry_run"
+fi
+python src/main.py \
+  -M 2 \
+  --reward_data_provider ${REWARD_DATA_PROVIDER} \
+  --node_addr_public ${TEZOS_NODE_ADDR} \
+  --node_endpoint ${TEZOS_NODE_ADDR} \
+  --base_directory /trd \
+  --signer_endpoint ${SIGNER_ADDR} \
+  --release_override ${RELEASE_OVERRIDE} \
+  --initial_cycle ${INITIAL_CYCLE} \
+  -N ${NETWORK} \
+  ${EXTRA_TRD_ARGS} \
+  ${dry_run_arg}

--- a/charts/tezos-reward-distributor/templates/config.yaml
+++ b/charts/tezos-reward-distributor/templates/config.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: tezos-reward-distributor-config
+  name: {{ include "tezos-reward-distributor.fullname" . }}-config
 data:
   config.yaml: |2+
     {{ toYaml $.Values.trd_config |nindent 4}}

--- a/charts/tezos-reward-distributor/templates/cronjob.yaml
+++ b/charts/tezos-reward-distributor/templates/cronjob.yaml
@@ -27,10 +27,10 @@ spec:
           volumes:
             - name: storage
               persistentVolumeClaim:
-                claimName: tezos-reward-distributor-volume
+                claimName: {{ include "tezos-reward-distributor.fullname" . }}-volume
             - name: config-volume
               configMap:
-                 name: tezos-reward-distributor-config
+                name: {{ include "tezos-reward-distributor.fullname" . }}-config
           initContainers:
             # Work around a bug where fsGroup is ignored
             - name: change-ownership-container

--- a/charts/tezos-reward-distributor/templates/cronjob.yaml
+++ b/charts/tezos-reward-distributor/templates/cronjob.yaml
@@ -31,6 +31,9 @@ spec:
             - name: config-volume
               configMap:
                 name: {{ include "tezos-reward-distributor.fullname" . }}-config
+            - name: secret-volume
+              secret:
+                secretName: {{ include "tezos-reward-distributor.fullname" . }}-secret
           initContainers:
             # Work around a bug where fsGroup is ignored
             - name: change-ownership-container
@@ -83,6 +86,9 @@ spec:
               volumeMounts:
               - mountPath: /trd
                 name: storage
+              - mountPath: /trd/cfg/aws_secret_access_key
+                name: secret-volume
+                subPath: aws_secret_access_key
               command:
               - /bin/sh
               args:

--- a/charts/tezos-reward-distributor/templates/cronjob.yaml
+++ b/charts/tezos-reward-distributor/templates/cronjob.yaml
@@ -100,4 +100,6 @@ spec:
                 value: "{{ .Values.bucket_upload.bucket_endpoint_url }}"
               - name: BUCKET_NAME
                 value: "{{ .Values.bucket_upload.bucket_name }}"
+              - name: BAKER_NAME
+                value: {{ include "tezos-reward-distributor.fullname" . }}
           restartPolicy: OnFailure

--- a/charts/tezos-reward-distributor/templates/cronjob.yaml
+++ b/charts/tezos-reward-distributor/templates/cronjob.yaml
@@ -7,8 +7,9 @@ metadata:
 spec:
 
   # important to prevent launch of concurrent payout processes
-  concurrencyPolicy:  Forbid
+  concurrencyPolicy: Forbid
 
+  failedJobsHistoryLimit: 100
   schedule: {{ .Values.schedule }}
   jobTemplate:
     metadata:

--- a/charts/tezos-reward-distributor/templates/cronjob.yaml
+++ b/charts/tezos-reward-distributor/templates/cronjob.yaml
@@ -57,5 +57,5 @@ spec:
             command:
             - /bin/sh
             - -c
-            - python src/main.py -M 2 --reward_data_provider {{ .Values.reward_data_provider }} --node_addr_public {{ .Values.tezos_node_addr }} --node_endpoint {{ .Values.tezos_node_addr }} --base_directory /trd --signer_endpoint {{ .Values.signer_addr }} {{ .Values.extra_trd_args }} -N {{ .Values.network }}
+            - python src/main.py -M 2 --reward_data_provider {{ .Values.reward_data_provider }} --node_addr_public {{ .Values.tezos_node_addr }} --node_endpoint {{ .Values.tezos_node_addr }} --base_directory /trd --signer_endpoint {{ .Values.signer_addr }} {{ .Values.extra_trd_args }} -N {{ .Values.network }} --initial_cycle {{ .Values.initial_cycle}} --release_override {{ .Values.release_override }} {{ if .Values.dry_run }}--dry_run {{ end }}
           restartPolicy: OnFailure

--- a/charts/tezos-reward-distributor/templates/cronjob.yaml
+++ b/charts/tezos-reward-distributor/templates/cronjob.yaml
@@ -86,9 +86,9 @@ spec:
               volumeMounts:
               - mountPath: /trd
                 name: storage
-              - mountPath: /trd/cfg/aws_secret_access_key
+              - mountPath: /trd/cfg/bucket_upload_secrets
                 name: secret-volume
-                subPath: aws_secret_access_key
+                subPath: bucket_upload_secrets
               command:
               - /bin/sh
               args:
@@ -96,12 +96,6 @@ spec:
               - |
 {{ tpl ($.Files.Get (print "scripts/bucket_upload.sh")) $ | indent 16 }}
               env:
-              - name: AWS_ACCESS_KEY_ID
-                value: "{{ .Values.bucket_upload.access_key_id }}"
-              - name: AWS_SECRET_ACCESS_KEY
-                value: "{{ .Values.bucket_upload.secret_access_key }}"
-              - name: AWS_DEFAULT_REGION
-                value: "{{ .Values.bucket_upload.default_region }}"
               - name: BUCKET_ENDPOINT_URL
                 value: "{{ .Values.bucket_upload.bucket_endpoint_url }}"
               - name: BUCKET_NAME

--- a/charts/tezos-reward-distributor/templates/cronjob.yaml
+++ b/charts/tezos-reward-distributor/templates/cronjob.yaml
@@ -45,37 +45,59 @@ spec:
               volumeMounts:
               - mountPath: /trd
                 name: storage
+            - name: tezos-reward-distributor-cron-job
+              image: {{ .Values.images.tezos_reward_distributor }}
+              imagePullPolicy: IfNotPresent
+              volumeMounts:
+                - mountPath: /trd
+                  name: storage
+                - mountPath: /trd/cfg/config.yaml
+                  name: config-volume
+                  subPath: config.yaml
+              command:
+              - /bin/sh
+              args:
+              - "-c"
+              - |
+{{ tpl ($.Files.Get (print "scripts/run.sh")) $ | indent 16 }}
+              env:
+              - name: REWARD_DATA_PROVIDER
+                value: "{{ .Values.reward_data_provider }}"
+              - name: TEZOS_NODE_ADDR
+                value: "{{ .Values.tezos_node_addr }}"
+              - name: SIGNER_ADDR
+                value: "{{ .Values.signer_addr }}"
+              - name: EXTRA_TRD_ARGS
+                value: "{{ .Values.extra_trd_args }}"
+              - name: NETWORK
+                value: "{{ .Values.network }}"
+              - name: RELEASE_OVERRIDE
+                value: "{{ .Values.release_override }}"
+              - name: INITIAL_CYCLE
+                value: "{{ .Values.initial_cycle }}"
+              - name: DRY_RUN
+                value: "{{ .Values.dry_run }}"
           containers:
-          - name: tezos-reward-distributor-cron-job
-            image: {{ .Values.images.tezos_reward_distributor }}
-            imagePullPolicy: IfNotPresent
-            volumeMounts:
+            - name: report-uploader
+              image: {{ .Values.tezos_k8s_images.snapshotEngine }}
+              volumeMounts:
               - mountPath: /trd
                 name: storage
-              - mountPath: /trd/cfg/config.yaml
-                name: config-volume
-                subPath: config.yaml
-            command:
-            - /bin/sh
-            args:
-            - "-c"
-            - |
-{{ tpl ($.Files.Get (print "scripts/run.sh")) $ | indent 14 }}
-            env:
-            - name: REWARD_DATA_PROVIDER
-              value: "{{ .Values.reward_data_provider }}"
-            - name: TEZOS_NODE_ADDR
-              value: "{{ .Values.tezos_node_addr }}"
-            - name: SIGNER_ADDR
-              value: "{{ .Values.signer_addr }}"
-            - name: EXTRA_TRD_ARGS
-              value: "{{ .Values.extra_trd_args }}"
-            - name: NETWORK
-              value: "{{ .Values.network }}"
-            - name: RELEASE_OVERRIDE
-              value: "{{ .Values.release_override }}"
-            - name: INITIAL_CYCLE
-              value: "{{ .Values.initial_cycle }}"
-            - name: DRY_RUN
-              value: "{{ .Values.dry_run }}"
+              command:
+              - /bin/sh
+              args:
+              - "-c"
+              - |
+{{ tpl ($.Files.Get (print "scripts/bucket_upload.sh")) $ | indent 16 }}
+              env:
+              - name: AWS_ACCESS_KEY_ID
+                value: "{{ .Values.bucket_upload.access_key_id }}"
+              - name: AWS_SECRET_ACCESS_KEY
+                value: "{{ .Values.bucket_upload.secret_access_key }}"
+              - name: AWS_DEFAULT_REGION
+                value: "{{ .Values.bucket_upload.default_region }}"
+              - name: BUCKET_ENDPOINT_URL
+                value: "{{ .Values.bucket_upload.bucket_endpoint_url }}"
+              - name: BUCKET_NAME
+                value: "{{ .Values.bucket_upload.bucket_name }}"
           restartPolicy: OnFailure

--- a/charts/tezos-reward-distributor/templates/cronjob.yaml
+++ b/charts/tezos-reward-distributor/templates/cronjob.yaml
@@ -57,5 +57,5 @@ spec:
             command:
             - /bin/sh
             - -c
-            - python src/main.py -M 2 --reward_data_provider {{ .Values.reward_data_provider }} --node_addr_public {{ .Values.tezos_node_addr }} --node_endpoint {{ .Values.tezos_node_addr }} --base_directory /trd --signer_endpoint {{ .Values.signer_addr }} {{ .Values.extra_trd_args }} -N GHOSTNET
+            - python src/main.py -M 2 --reward_data_provider {{ .Values.reward_data_provider }} --node_addr_public {{ .Values.tezos_node_addr }} --node_endpoint {{ .Values.tezos_node_addr }} --base_directory /trd --signer_endpoint {{ .Values.signer_addr }} {{ .Values.extra_trd_args }} -N {{ .Values.network }}
           restartPolicy: OnFailure

--- a/charts/tezos-reward-distributor/templates/cronjob.yaml
+++ b/charts/tezos-reward-distributor/templates/cronjob.yaml
@@ -62,19 +62,19 @@ spec:
 {{ tpl ($.Files.Get (print "scripts/run.sh")) $ | indent 14 }}
             env:
             - name: REWARD_DATA_PROVIDER
-              value: {{ .Values.reward_data_provider }}
+              value: "{{ .Values.reward_data_provider }}"
             - name: TEZOS_NODE_ADDR
-              value: {{ .Values.tezos_node_addr }}
+              value: "{{ .Values.tezos_node_addr }}"
             - name: SIGNER_ADDR
-              value: {{ .Values.signer_addr }}
+              value: "{{ .Values.signer_addr }}"
             - name: EXTRA_TRD_ARGS
-              value: {{ .Values.extra_trd_args }}
+              value: "{{ .Values.extra_trd_args }}"
             - name: NETWORK
-              value: {{ .Values.network }}
+              value: "{{ .Values.network }}"
             - name: RELEASE_OVERRIDE
-              value: {{ .Values.release_override }}
+              value: "{{ .Values.release_override }}"
             - name: INITIAL_CYCLE
-              value: {{ .Values.initial_cycle }}
+              value: "{{ .Values.initial_cycle }}"
             - name: DRY_RUN
-              value: {{ .Values.dry_run }}
+              value: "{{ .Values.dry_run }}"
           restartPolicy: OnFailure

--- a/charts/tezos-reward-distributor/templates/cronjob.yaml
+++ b/charts/tezos-reward-distributor/templates/cronjob.yaml
@@ -56,6 +56,25 @@ spec:
                 subPath: config.yaml
             command:
             - /bin/sh
-            - -c
-            - python src/main.py -M 2 --reward_data_provider {{ .Values.reward_data_provider }} --node_addr_public {{ .Values.tezos_node_addr }} --node_endpoint {{ .Values.tezos_node_addr }} --base_directory /trd --signer_endpoint {{ .Values.signer_addr }} {{ .Values.extra_trd_args }} -N {{ .Values.network }} --initial_cycle {{ .Values.initial_cycle}} --release_override {{ .Values.release_override }} {{ if .Values.dry_run }}--dry_run {{ end }}
+            args:
+            - "-c"
+            - |
+{{ tpl ($.Files.Get (print "scripts/run.sh")) $ | indent 14 }}
+            env:
+            - name: REWARD_DATA_PROVIDER
+              value: {{ .Values.reward_data_provider }}
+            - name: TEZOS_NODE_ADDR
+              value: {{ .Values.tezos_node_addr }}
+            - name: SIGNER_ADDR
+              value: {{ .Values.signer_addr }}
+            - name: EXTRA_TRD_ARGS
+              value: {{ .Values.extra_trd_args }}
+            - name: NETWORK
+              value: {{ .Values.network }}
+            - name: RELEASE_OVERRIDE
+              value: {{ .Values.release_override }}
+            - name: INITIAL_CYCLE
+              value: {{ .Values.initial_cycle }}
+            - name: DRY_RUN
+              value: {{ .Values.dry_run }}
           restartPolicy: OnFailure

--- a/charts/tezos-reward-distributor/templates/secrets.yaml
+++ b/charts/tezos-reward-distributor/templates/secrets.yaml
@@ -3,4 +3,4 @@ kind: Secret
 metadata:
   name: {{ include "tezos-reward-distributor.fullname" . }}-secret
 data:
-  AWS_SECRET_ACCESS_KEY: {{ .Values.bucket_upload_secrets.secret_access_key | b64enc }}
+  bucket_upload_secrets: {{ tpl (.Files.Get "scripts/bucket_upload_secrets") . | b64enc | quote }}

--- a/charts/tezos-reward-distributor/templates/secrets.yaml
+++ b/charts/tezos-reward-distributor/templates/secrets.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "tezos-reward-distributor.fullname" . }}-secret
+data:
+  AWS_SECRET_ACCESS_KEY: {{ .Values.bucket_upload_secrets.secret_access_key | b64enc }}

--- a/charts/tezos-reward-distributor/templates/volume.yaml
+++ b/charts/tezos-reward-distributor/templates/volume.yaml
@@ -1,7 +1,7 @@
 apiVersion: "v1"
 kind: PersistentVolumeClaim
 metadata:
-  name: tezos-reward-distributor-volume
+  name: {{ include "tezos-reward-distributor.fullname" . }}-volume
 spec:
  storageClassName:
  accessModes:

--- a/charts/tezos-reward-distributor/values.yaml
+++ b/charts/tezos-reward-distributor/values.yaml
@@ -117,7 +117,8 @@ trd_config:
 # when the cronjob is not running.
 bucket_upload:
   access_key_id:
-  secret_access_key:
   default_region:
   bucket_endpoint_url:
   bucket_name: 
+bucket_upload_secrets:
+  secret_access_key:

--- a/charts/tezos-reward-distributor/values.yaml
+++ b/charts/tezos-reward-distributor/values.yaml
@@ -26,74 +26,83 @@ reward_data_provider: "rpc"
 # Tezos Network. Can be MAINNET or GHOSTNET
 network: MAINNET
 
+# Release override: set to -5 to pay just finished cycle
+release_override: -5
+
+# Set initial cycle to pay rewards from. Set to -1 to start from just finished cycle.
+initial_cycle: -1
+
+# Dry-run. Set to "true" to not actually perform the payouts.
+dry_run: false
+
 extra_trd_args: "--do_not_publish_stats"
 
 # This is an example of TRD config. Customize to your needs.
 # For details, please consult TRD documentation:
 #  https://tezos-reward-distributor-organization.github.io/tezos-reward-distributor/
 trd_config:
-  version: 1.0
-  baking_address: tz1WrZpjVRpsmjv8VL3781RhyLi5JyHsGXK2
-  payment_address: tz1WrZpjVRpsmjv8VL3781RhyLi5JyHsGXK2
-  rewards_type: actual
-  service_fee: 4.5
-  founders_map:
-    {'tz1WrZpjVRpsmjv8VL3781RhyLi5JyHsGXK2' : 1.0}
-  owners_map:
-    {'tz1eawTP2ueRCqsYZq3DebwW9PkthdCqcZa8' : 0.3,
-     'tz1WrZpjVRpsmjv8VL3781RhyLi5JyHsGXK2' : 0.7}
-  specials_map: {}
-  supporters_set: {}
-  min_delegation_amt: 100
-  reactivate_zeroed: True
-  delegator_pays_xfer_fee: True
-  delegator_pays_ra_fee: True
-  pay_denunciation_rewards: True
-  rules_map:
-    KT1MMhmTkUoHez4u58XMZL7NkpU9FWY4QLn3: KT1MMhmTkUoHez4u58XMZL7NkpU9FWY4QLn0
-    KT1D33n8zp1bqBkViiQtLLPLEGRW9xcqihY3: KT1MMhmTkUoHez4u58XMZL7NkpU9FWY4QLn0
-    KT1Ao8UXNJ9Dz71Wx3m8yzYNdnNQp2peqtM0: TOE
-    KT1VyxJWhe9oz3v4qwTp2U6Rb17ocHGpJmW0: TOB
-    KT19cJWfbDNXT4azVbgTBvtLMeqweuHH8W20: TOF
-    KT1DextebDNXT4azVbgTBvtLMeqweuHH8W20: Dexter
-    mindelegation: TOB
-  plugins:
-    enabled:
-    - webhook
-    email:
-      smtp_user: user@example.com
-      smtp_pass: horsebatterystaple2
-      smtp_host: smtp.example.com
-      smtp_port: 587
-      smtp_tls: true
-      smtp_sender: trdnotice@example.com
-      smtp_recipients:
-        - bob@example.com
-        - alice@example.com
-    telegram:
-      admin_chat_ids:
-        - 123456789
-      payouts_chat_ids:
-        - -13134455
-      bot_api_key: 988877766:SKDJFLSJDFJLJSKDFJLKSDJFLKJDF
-      telegram_text: >
-        Rewards for cycle %CYCLE% are completed.
-        We paid out %TREWARDS% tez in rewards to %NDELEGATORS% delegators.
-    twitter:
-      api_key: XXXXXXXX
-      api_secret: ZZZZZZZZ
-      access_token: YYYYYYYY
-      access_secret: WWWWWWWW
-      extra_tags:
-        - "our_baker"
-        - "tezos"
-        - "rewards"
-    webhook:
-      endpoint: https://example.com/webhook.php
-      token: Xynl6svphysd3BhjLP6IS
-    discord:
-      endpoint: https://discord.com/api/webhooks/9876543212345678/OmAfadfasdfasdfasdfasdfasdfasfsdf
-      send_admin: False
-      discord_text: >
-        Rewards for cycle %CYCLE% are completed.
-        We paid out %TREWARDS% tez in rewards to %NDELEGATORS% delegators.
+  # version: 1.0
+  # baking_address: tz1WrZpjVRpsmjv8VL3781RhyLi5JyHsGXK2
+  # payment_address: tz1WrZpjVRpsmjv8VL3781RhyLi5JyHsGXK2
+  # rewards_type: actual
+  # service_fee: 4.5
+  # founders_map:
+  #   {'tz1WrZpjVRpsmjv8VL3781RhyLi5JyHsGXK2' : 1.0}
+  # owners_map:
+  #   {'tz1eawTP2ueRCqsYZq3DebwW9PkthdCqcZa8' : 0.3,
+  #    'tz1WrZpjVRpsmjv8VL3781RhyLi5JyHsGXK2' : 0.7}
+  # specials_map: {}
+  # supporters_set: {}
+  # min_delegation_amt: 100
+  # reactivate_zeroed: True
+  # delegator_pays_xfer_fee: True
+  # delegator_pays_ra_fee: True
+  # pay_denunciation_rewards: True
+  # rules_map:
+  #   KT1MMhmTkUoHez4u58XMZL7NkpU9FWY4QLn3: KT1MMhmTkUoHez4u58XMZL7NkpU9FWY4QLn0
+  #   KT1D33n8zp1bqBkViiQtLLPLEGRW9xcqihY3: KT1MMhmTkUoHez4u58XMZL7NkpU9FWY4QLn0
+  #   KT1Ao8UXNJ9Dz71Wx3m8yzYNdnNQp2peqtM0: TOE
+  #   KT1VyxJWhe9oz3v4qwTp2U6Rb17ocHGpJmW0: TOB
+  #   KT19cJWfbDNXT4azVbgTBvtLMeqweuHH8W20: TOF
+  #   KT1DextebDNXT4azVbgTBvtLMeqweuHH8W20: Dexter
+  #   mindelegation: TOB
+  # plugins:
+  #   enabled:
+  #   - webhook
+  #   email:
+  #     smtp_user: user@example.com
+  #     smtp_pass: horsebatterystaple2
+  #     smtp_host: smtp.example.com
+  #     smtp_port: 587
+  #     smtp_tls: true
+  #     smtp_sender: trdnotice@example.com
+  #     smtp_recipients:
+  #       - bob@example.com
+  #       - alice@example.com
+  #   telegram:
+  #     admin_chat_ids:
+  #       - 123456789
+  #     payouts_chat_ids:
+  #       - -13134455
+  #     bot_api_key: 988877766:SKDJFLSJDFJLJSKDFJLKSDJFLKJDF
+  #     telegram_text: >
+  #       Rewards for cycle %CYCLE% are completed.
+  #       We paid out %TREWARDS% tez in rewards to %NDELEGATORS% delegators.
+  #   twitter:
+  #     api_key: XXXXXXXX
+  #     api_secret: ZZZZZZZZ
+  #     access_token: YYYYYYYY
+  #     access_secret: WWWWWWWW
+  #     extra_tags:
+  #       - "our_baker"
+  #       - "tezos"
+  #       - "rewards"
+  #   webhook:
+  #     endpoint: https://example.com/webhook.php
+  #     token: Xynl6svphysd3BhjLP6IS
+  #   discord:
+  #     endpoint: https://discord.com/api/webhooks/9876543212345678/OmAfadfasdfasdfasdfasdfasdfasfsdf
+  #     send_admin: False
+  #     discord_text: >
+  #       Rewards for cycle %CYCLE% are completed.
+  #       We paid out %TREWARDS% tez in rewards to %NDELEGATORS% delegators.

--- a/charts/tezos-reward-distributor/values.yaml
+++ b/charts/tezos-reward-distributor/values.yaml
@@ -116,9 +116,9 @@ trd_config:
 # optionally upload all TRD state to a bucket. This allows all data to be examined
 # when the cronjob is not running.
 bucket_upload:
-  access_key_id:
-  default_region:
   bucket_endpoint_url:
   bucket_name: 
 bucket_upload_secrets:
+  access_key_id:
+  default_region:
   secret_access_key:

--- a/charts/tezos-reward-distributor/values.yaml
+++ b/charts/tezos-reward-distributor/values.yaml
@@ -1,6 +1,12 @@
 images:
   tezos_reward_distributor: trdo/tezos-reward-distributor:latest
 
+tezos_k8s_images:
+  # snapshotEngine is needed for upload of logs to bucket
+  # since it already exists, we do not create a new container
+  # just for this task.
+  snapshotEngine: ghcr.io/oxheadalpha/tezos-k8s-snapshotengine:master
+
 # The node endpoint. It must be an archive node.
 # May start with https://
 # Default value will connect to a tezos-k8s private chain running in the same workspace, with
@@ -106,3 +112,12 @@ trd_config:
   #     discord_text: >
   #       Rewards for cycle %CYCLE% are completed.
   #       We paid out %TREWARDS% tez in rewards to %NDELEGATORS% delegators.
+
+# optionally upload all TRD state to a bucket. This allows all data to be examined
+# when the cronjob is not running.
+bucket_upload:
+  access_key_id:
+  secret_access_key:
+  default_region:
+  bucket_endpoint_url:
+  bucket_name: 

--- a/charts/tezos-reward-distributor/values.yaml
+++ b/charts/tezos-reward-distributor/values.yaml
@@ -23,6 +23,9 @@ schedule: "0 */6 * * *"
 # Pick one of "rpc", "tzstats", "tzkt"
 reward_data_provider: "rpc"
 
+# Tezos Network. Can be MAINNET or GHOSTNET
+network: MAINNET
+
 extra_trd_args: "--do_not_publish_stats"
 
 # This is an example of TRD config. Customize to your needs.


### PR DESCRIPTION
I deployed TRD against a mainnet baker with tezos-k8s and found a few missing parameters from the original work. Adding them.

Also, I am commenting out by default the TRD params in values.yaml, otherwise they get deep-merged by helm, which yields odd results.

I am also adding the option to upload the resulting data from trd to a bucket. Since TRD runs in a cronjob, it's hard to shell into it to look at the files. Uploading the entire PVC to a bucket is a nice substitute.