### PR TITLE
515 snapshot engine implement restriction on artifact creating frequency

### DIFF
--- a/charts/snapshotEngine/templates/configmap.yaml
+++ b/charts/snapshotEngine/templates/configmap.yaml
@@ -10,6 +10,8 @@ data:
   DISABLE_STORAGE_INIT_TIME: {{ $.Values.disableStorageInitTime | quote }}
   NETWORK_OVERRIDE: {{ $.Values.networkOverride | default "" | quote }}
   ALL_SUBDOMAINS: {{ $.Values.allSubdomains }}
+  ARCHIVE_SLEEP_DELAY: {{ $.Values.artifactDelay.archive }}
+  ROLLING_SLEEP_DELAY: {{ $.Values.artifactDelay.rolling }}
 kind: ConfigMap
 metadata:
   name: snapshot-configmap

--- a/charts/snapshotEngine/values.yaml
+++ b/charts/snapshotEngine/values.yaml
@@ -88,3 +88,11 @@ networkOverride: ""
 # List of all xtz-shots subdomains
 allSubdomains: ""
 
+# If you find aftifacts are being created too frequently whether it be compute/storage cost reduction, or difficulty in managing
+# the quantity of files generated, a sleep value can be updated here to delay the creation of artifacts. This can be expecially 
+# useful with small/test networks that are small in size and create every 20 minutes or so.
+# Valid values include an integer followed by a single-character time unit denoting days, minutes hours seconds- d, h, m, s
+# Ex: 1d, 2h, 25m, 59s, etc.
+artifactDelay:
+  rolling: 0m
+  archive: 0m

--- a/snapshotEngine/snapshot-maker.sh
+++ b/snapshotEngine/snapshot-maker.sh
@@ -2,6 +2,26 @@
 
 cd /
 
+SLEEP_TIME=0m
+
+if [ "${HISTORY_MODE}" = "archive" ]; then
+    SLEEP_TIME="${ARCHIVE_SLEEP_DELAY}"
+    if [ "${ARCHIVE_SLEEP_DELAY}" != "0m" ]; then
+        printf "%s artifactDelay.archive is set to %s sleeping...\n" "$(date "+%Y-%m-%d %H:%M:%S" "$@")" "${ARCHIVE_SLEEP_DELAY}"
+    fi
+elif [ "${HISTORY_MODE}" = "rolling" ]; then
+    SLEEP_TIME="${ROLLING_SLEEP_DELAY}"
+    if [ "${ROLLING_SLEEP_DELAY}" != "0m" ]; then
+        printf "%s artifactDelay.rolling is set to %s sleeping...\n" "$(date "+%Y-%m-%d %H:%M:%S" "$@")" "${ROLLING_SLEEP_DELAY}"
+    fi
+fi
+
+if [ "${SLEEP_TIME}" = "0m" ]; then
+    printf "%s artifactDelay.HISTORY_MODE was not set! No delay...\n" "$(date "+%Y-%m-%d %H:%M:%S" "$@")"
+fi
+
+sleep "${SLEEP_TIME}"
+
 ZIP_AND_UPLOAD_JOB_NAME=zip-and-upload-"${HISTORY_MODE}"
 
 # Pause if nodes are not ready


### PR DESCRIPTION
Snapshot Engine creates artifacts back-to-back by default. As soon as one job is done another one is started.  This can create A LOT of artifacts especially for non-mainnet networks.  This can be a headache to manage so many files and also could be very expensive to host. We've decided to implement a simple configurable parameter in the helm values for the snapshotEngine chart that will allow the job to delay for a user-determined amount of time.

**Usage:**
in the snapshot-values.yaml file one would put their desired sleep time (a valid unix sleep time value) as such -
```yaml
artifactDelay:
  rolling: 1m
  archive: 0m
```

This will delay the artifact generation by a user determined amount of time for a given chain namespace and a chain history mode.

**Notes:**
It is a rudimentary  feature for the time being.  The time is not factored in to artifact generation time. For example rolling snapshots on Mainnet take about 8 hours, so any value less than the artifact generation time for a given history mode and network will be ignored. Think of this value as more of a "floor" value.  **No artifact will take less time than the configured time value.**

Eventually we would like this time value to reflect the total amount of time (including artifact generation time), but this will require some complex calculations and record keeping of generation time.  Another caveat would be a fresh deployment "guessing" what the first amount of time will be.  For now we have this simple delay implemented.