### PR TITLE
Handle Metadata from xtz-shots

### DIFF
--- a/charts/tezos/scripts/snapshot-importer.sh
+++ b/charts/tezos/scripts/snapshot-importer.sh
@@ -1,4 +1,4 @@
-set -ex
+set -e
 
 bin_dir="/usr/local/bin"
 data_dir="/var/tezos"
@@ -6,6 +6,14 @@ node_dir="$data_dir/node"
 node_data_dir="$node_dir/data"
 node="$bin_dir/tezos-node"
 snapshot_file=${node_dir}/chain.snapshot
+if [ -f ${node_dir}/chain.snapshot.block_hash ]; then
+    block_hash=$(cat ${node_dir}/chain.snapshot.block_hash)
+fi
+
+if [ ! -f ${snapshot_file} ]; then
+    echo "No snapshot to import."
+    exit 0
+fi
 
 if [ -d ${node_data_dir}/context ]; then
     echo "Blockchain has already been imported. If a tarball"
@@ -16,8 +24,12 @@ fi
 
 cp -v /etc/tezos/config.json ${node_data_dir}
 
+if [ "${block_hash}" != "" ]; then
+  block_hash_arg="--block ${block_hash}"
+fi
+
 ${node} snapshot import ${snapshot_file} --data-dir ${node_data_dir} \
-    --network $CHAIN_NAME
+    --network $CHAIN_NAME ${block_hash_arg}
 find ${node_dir}
 
 rm -rvf ${snapshot_file}

--- a/charts/tezos/scripts/snapshot-importer.sh
+++ b/charts/tezos/scripts/snapshot-importer.sh
@@ -12,10 +12,6 @@ if [ ! -f ${snapshot_file} ]; then
     exit 0
 fi
 
-if [ -f ${node_dir}/chain.snapshot.block_hash ]; then
-    block_hash=$(cat ${node_dir}/chain.snapshot.block_hash)
-fi
-
 if [ -d ${node_data_dir}/context ]; then
     echo "Blockchain has already been imported. If a tarball"
     echo "instead of a regular tezos snapshot was used, it was"
@@ -25,8 +21,8 @@ fi
 
 cp -v /etc/tezos/config.json ${node_data_dir}
 
-if [ "${block_hash}" != "" ]; then
-  block_hash_arg="--block ${block_hash}"
+if [ -f ${node_dir}/chain.snapshot.block_hash ]; then
+    block_hash_arg="--block $(cat ${node_dir}/chain.snapshot.block_hash)"
 fi
 
 ${node} snapshot import ${snapshot_file} --data-dir ${node_data_dir} \

--- a/charts/tezos/scripts/snapshot-importer.sh
+++ b/charts/tezos/scripts/snapshot-importer.sh
@@ -6,13 +6,14 @@ node_dir="$data_dir/node"
 node_data_dir="$node_dir/data"
 node="$bin_dir/octez-node"
 snapshot_file=${node_dir}/chain.snapshot
-if [ -f ${node_dir}/chain.snapshot.block_hash ]; then
-    block_hash=$(cat ${node_dir}/chain.snapshot.block_hash)
-fi
 
 if [ ! -f ${snapshot_file} ]; then
     echo "No snapshot to import."
     exit 0
+fi
+
+if [ -f ${node_dir}/chain.snapshot.block_hash ]; then
+    block_hash=$(cat ${node_dir}/chain.snapshot.block_hash)
 fi
 
 if [ -d ${node_data_dir}/context ]; then

--- a/charts/tezos/templates/_helpers.tpl
+++ b/charts/tezos/templates/_helpers.tpl
@@ -56,7 +56,7 @@
 {{- define "tezos.shouldDownloadSnapshot" -}}
   {{- if or (.Values.full_snapshot_url) (.Values.full_tarball_url)
             (.Values.rolling_snapshot_url) (.Values.rolling_tarball_url)
-            (.Values.archive_tarball_url) }}
+            (.Values.archive_tarball_url) (.Values.snapshot_source) }}
     {{- if or (and (.Values.rolling_tarball_url) (.Values.rolling_snapshot_url))
         (and (.Values.full_tarball_url) (.Values.full_snapshot_url))
     }}

--- a/charts/tezos/templates/configs.yaml
+++ b/charts/tezos/templates/configs.yaml
@@ -16,6 +16,9 @@ data:
   ROLLING_SNAPSHOT_URL: "{{ .Values.rolling_snapshot_url }}"
   ROLLING_TARBALL_URL: "{{ .Values.rolling_tarball_url }}"
   ARCHIVE_TARBALL_URL: "{{ .Values.archive_tarball_url }}"
+  PREFER_TARBALLS: "{{ .Values.prefer_tarballs }}"
+  SNAPSHOT_SOURCE: "{{ .Values.snapshot_source }}"
+  OCTEZ_VERSION: "{{ .Values.images.octez }}"
   NODE_GLOBALS: |
 {{ .Values.node_globals | mustToPrettyJson | indent 4 }}
 

--- a/charts/tezos/values.yaml
+++ b/charts/tezos/values.yaml
@@ -287,16 +287,15 @@ snapshot_source: https://xtz-shots.io/tezos-snapshots.json
 prefer_tarballs: false
 
 # By default, tezos-k8s will attempt to download the right artifact from
-# `snapshot_source` set above.
-# You can override and hard-code a snapshot URL source below.
-# When any of the below variables is set, `snapshot_source` above will be
-# ignored for all artifact types.
+# `snapshot_source` set above. You can override and hard-code a snapshot URL
+# source below. When any of the below variables are set, `snapshot_source` above
+# will be ignored for all artifact types.
 ## NOTE: `*_tarball_url` and `*_snapshot_url` are mutually exclusive
 ## and cannot both be specified at the same time.
+archive_tarball_url: null # e.g. https://mainnet.xtz-shots.io/archive-tarball
 full_snapshot_url: null
 full_tarball_url: null
 rolling_snapshot_url: null
-archive_tarball_url: null
 rolling_tarball_url: null
 
 # List of peers for nodes to connect to. Gets set under config.json `p2p` field

--- a/charts/tezos/values.yaml
+++ b/charts/tezos/values.yaml
@@ -273,10 +273,10 @@ signers: {}
 # ```
 # End Signers
 
-# When spinning up nodes, tezos-k8s will attempt to download a snapshot
-# from a known source.
-# If you want to sync from scratch, set to 'null'
-# For a private chain, set to 'null'
+# When spinning up nodes, tezos-k8s will attempt to download a snapshot from a
+# known source. This should be a url to a json metadata file in the format
+# xtz-shots uses. If you want to sync from scratch or for a private chain, set
+# to `null`.
 snapshot_source: https://xtz-shots.io/tezos-snapshots.json
 
 # By default, tezos-k8s will download and unpack snapshots.

--- a/charts/tezos/values.yaml
+++ b/charts/tezos/values.yaml
@@ -265,17 +265,31 @@ signers: {}
 # ```
 # End Signers
 
-## Where full and rolling history mode nodes will get their Tezos snapshots from.
-full_snapshot_url: https://mainnet.xtz-shots.io/full
-rolling_snapshot_url: https://mainnet.xtz-shots.io/rolling
+# When spinning up nodes, tezos-k8s will attempt to download a snapshot
+# from a known source.
+# If you want to sync from scratch, set to 'null'
+# For a private chain, set to 'null'
+snapshot_source: https://xtz-shots.io/tezos-snapshots.json
 
-## Alternatively to a Tezos snapshot, you can download an LZ4-compressed
-## filesystem tar of a node's data directory by setting `archive_tarball_url`
-## and `rolling_tarball_url` fields to the URL of the file. NOTE:
-## `rolling_tarball_url` and `rolling_snapshot_url` are mutually exclusive and
-## cannot both be specified at the same time.
-archive_tarball_url: https://mainnet.xtz-shots.io/archive-tarball
-# rolling_tarball_url: "https://mainnet.xtz-shots.io/rolling-tarball
+# By default, tezos-k8s will download and unpack snapshots.
+# A tarball is a LZ4-compressed filesystem tar of a node's data directory.
+# You must trust the tarball provider to provide good data, as no check is
+# performed by the node.
+# If you prefer tarballs, set to "true" below.
+prefer_tarballs: false
+
+# By default, tezos-k8s will attempt to download the right artifact from
+# `snapshot_source` set above.
+# You can override and hard-code a snapshot URL source below.
+# When any of the below variables is set, `snapshot_source` above will be
+# ignored for all artifact types.
+## NOTE: `*_tarball_url` and `*_snapshot_url` are mutually exclusive
+## and cannot both be specified at the same time.
+full_snapshot_url: null
+full_tarball_url: null
+rolling_snapshot_url: null
+archive_tarball_url: null
+rolling_tarball_url: null
 
 # List of peers for nodes to connect to. Gets set under config.json `p2p` field
 bootstrap_peers: []

--- a/mkchain/tqchain/mkchain.py
+++ b/mkchain/tqchain/mkchain.py
@@ -178,10 +178,7 @@ def main():
             "zerotier_token": args.zerotier_token,
         },
         # Custom chains should not pull snapshots or tarballs
-        "full_snapshot_url": None,
-        "rolling_snapshot_url": None,
-        "archive_tarball_url": None,
-        "rolling_tarball_url": None,
+        "snapshot_source": None,
         "node_globals": {
             # Needs a quotedstring otherwise helm interprets "Y" as true and it does not work
             "env": {

--- a/test/charts/mainnet.expect.yaml
+++ b/test/charts/mainnet.expect.yaml
@@ -33,7 +33,7 @@ data:
   ARCHIVE_TARBALL_URL: ""
   PREFER_TARBALLS: "false"
   SNAPSHOT_SOURCE: "https://xtz-shots.io/tezos-snapshots.json"
-  OCTEZ_VERSION: "tezos/tezos:v14-release"
+  OCTEZ_VERSION: "tezos/tezos:v15-release"
   NODE_GLOBALS: |
     {
       "env": {}
@@ -328,9 +328,6 @@ spec:
               node_data_dir="$node_dir/data"
               node="$bin_dir/octez-node"
               snapshot_file=${node_dir}/chain.snapshot
-              if [ -f ${node_dir}/chain.snapshot.block_hash ]; then
-                  block_hash=$(cat ${node_dir}/chain.snapshot.block_hash)
-              fi
               
               if [ ! -f ${snapshot_file} ]; then
                   echo "No snapshot to import."
@@ -346,8 +343,8 @@ spec:
               
               cp -v /etc/tezos/config.json ${node_data_dir}
               
-              if [ "${block_hash}" != "" ]; then
-                block_hash_arg="--block ${block_hash}"
+              if [ -f ${node_dir}/chain.snapshot.block_hash ]; then
+                  block_hash_arg="--block $(cat ${node_dir}/chain.snapshot.block_hash)"
               fi
               
               ${node} snapshot import ${snapshot_file} --data-dir ${node_data_dir} \

--- a/test/charts/mainnet.expect.yaml
+++ b/test/charts/mainnet.expect.yaml
@@ -26,11 +26,14 @@ data:
         },
       "protocol_activation": null
     }
-  FULL_SNAPSHOT_URL: "https://mainnet.xtz-shots.io/full"
+  FULL_SNAPSHOT_URL: ""
   FULL_TARBALL_URL: ""
-  ROLLING_SNAPSHOT_URL: "https://mainnet.xtz-shots.io/rolling"
+  ROLLING_SNAPSHOT_URL: ""
   ROLLING_TARBALL_URL: ""
-  ARCHIVE_TARBALL_URL: "https://mainnet.xtz-shots.io/archive-tarball"
+  ARCHIVE_TARBALL_URL: ""
+  PREFER_TARBALLS: "false"
+  SNAPSHOT_SOURCE: "https://xtz-shots.io/tezos-snapshots.json"
+  OCTEZ_VERSION: "tezos/tezos:v14-release"
   NODE_GLOBALS: |
     {
       "env": {}
@@ -310,7 +313,7 @@ spec:
           args:
             - "-c"
             - |
-              set -ex
+              set -e
               
               bin_dir="/usr/local/bin"
               data_dir="/var/tezos"
@@ -318,6 +321,14 @@ spec:
               node_data_dir="$node_dir/data"
               node="$bin_dir/tezos-node"
               snapshot_file=${node_dir}/chain.snapshot
+              if [ -f ${node_dir}/chain.snapshot.block_hash ]; then
+                  block_hash=$(cat ${node_dir}/chain.snapshot.block_hash)
+              fi
+              
+              if [ ! -f ${snapshot_file} ]; then
+                  echo "No snapshot to import."
+                  exit 0
+              fi
               
               if [ -d ${node_data_dir}/context ]; then
                   echo "Blockchain has already been imported. If a tarball"
@@ -328,8 +339,12 @@ spec:
               
               cp -v /etc/tezos/config.json ${node_data_dir}
               
+              if [ "${block_hash}" != "" ]; then
+                block_hash_arg="--block ${block_hash}"
+              fi
+              
               ${node} snapshot import ${snapshot_file} --data-dir ${node_data_dir} \
-                  --network $CHAIN_NAME
+                  --network $CHAIN_NAME ${block_hash_arg}
               find ${node_dir}
               
               rm -rvf ${snapshot_file}

--- a/test/charts/mainnet2.expect.yaml
+++ b/test/charts/mainnet2.expect.yaml
@@ -26,11 +26,14 @@ data:
         },
       "protocol_activation": null
     }
-  FULL_SNAPSHOT_URL: "https://mainnet.xtz-shots.io/full"
+  FULL_SNAPSHOT_URL: ""
   FULL_TARBALL_URL: ""
-  ROLLING_SNAPSHOT_URL: "https://mainnet.xtz-shots.io/rolling"
+  ROLLING_SNAPSHOT_URL: ""
   ROLLING_TARBALL_URL: ""
-  ARCHIVE_TARBALL_URL: "https://mainnet.xtz-shots.io/archive-tarball"
+  ARCHIVE_TARBALL_URL: ""
+  PREFER_TARBALLS: "false"
+  SNAPSHOT_SOURCE: "https://xtz-shots.io/tezos-snapshots.json"
+  OCTEZ_VERSION: "tezos/tezos:v14-release"
   NODE_GLOBALS: |
     {
       "env": {
@@ -409,7 +412,7 @@ spec:
           args:
             - "-c"
             - |
-              set -ex
+              set -e
               
               bin_dir="/usr/local/bin"
               data_dir="/var/tezos"
@@ -417,6 +420,14 @@ spec:
               node_data_dir="$node_dir/data"
               node="$bin_dir/tezos-node"
               snapshot_file=${node_dir}/chain.snapshot
+              if [ -f ${node_dir}/chain.snapshot.block_hash ]; then
+                  block_hash=$(cat ${node_dir}/chain.snapshot.block_hash)
+              fi
+              
+              if [ ! -f ${snapshot_file} ]; then
+                  echo "No snapshot to import."
+                  exit 0
+              fi
               
               if [ -d ${node_data_dir}/context ]; then
                   echo "Blockchain has already been imported. If a tarball"
@@ -427,8 +438,12 @@ spec:
               
               cp -v /etc/tezos/config.json ${node_data_dir}
               
+              if [ "${block_hash}" != "" ]; then
+                block_hash_arg="--block ${block_hash}"
+              fi
+              
               ${node} snapshot import ${snapshot_file} --data-dir ${node_data_dir} \
-                  --network $CHAIN_NAME
+                  --network $CHAIN_NAME ${block_hash_arg}
               find ${node_dir}
               
               rm -rvf ${snapshot_file}
@@ -762,7 +777,7 @@ spec:
           args:
             - "-c"
             - |
-              set -ex
+              set -e
               
               bin_dir="/usr/local/bin"
               data_dir="/var/tezos"
@@ -770,6 +785,14 @@ spec:
               node_data_dir="$node_dir/data"
               node="$bin_dir/tezos-node"
               snapshot_file=${node_dir}/chain.snapshot
+              if [ -f ${node_dir}/chain.snapshot.block_hash ]; then
+                  block_hash=$(cat ${node_dir}/chain.snapshot.block_hash)
+              fi
+              
+              if [ ! -f ${snapshot_file} ]; then
+                  echo "No snapshot to import."
+                  exit 0
+              fi
               
               if [ -d ${node_data_dir}/context ]; then
                   echo "Blockchain has already been imported. If a tarball"
@@ -780,8 +803,12 @@ spec:
               
               cp -v /etc/tezos/config.json ${node_data_dir}
               
+              if [ "${block_hash}" != "" ]; then
+                block_hash_arg="--block ${block_hash}"
+              fi
+              
               ${node} snapshot import ${snapshot_file} --data-dir ${node_data_dir} \
-                  --network $CHAIN_NAME
+                  --network $CHAIN_NAME ${block_hash_arg}
               find ${node_dir}
               
               rm -rvf ${snapshot_file}

--- a/test/charts/mainnet2.expect.yaml
+++ b/test/charts/mainnet2.expect.yaml
@@ -33,7 +33,7 @@ data:
   ARCHIVE_TARBALL_URL: ""
   PREFER_TARBALLS: "false"
   SNAPSHOT_SOURCE: "https://xtz-shots.io/tezos-snapshots.json"
-  OCTEZ_VERSION: "tezos/tezos:v14-release"
+  OCTEZ_VERSION: "tezos/tezos:v15-release"
   NODE_GLOBALS: |
     {
       "env": {
@@ -437,9 +437,6 @@ spec:
               node_data_dir="$node_dir/data"
               node="$bin_dir/octez-node"
               snapshot_file=${node_dir}/chain.snapshot
-              if [ -f ${node_dir}/chain.snapshot.block_hash ]; then
-                  block_hash=$(cat ${node_dir}/chain.snapshot.block_hash)
-              fi
               
               if [ ! -f ${snapshot_file} ]; then
                   echo "No snapshot to import."
@@ -455,8 +452,8 @@ spec:
               
               cp -v /etc/tezos/config.json ${node_data_dir}
               
-              if [ "${block_hash}" != "" ]; then
-                block_hash_arg="--block ${block_hash}"
+              if [ -f ${node_dir}/chain.snapshot.block_hash ]; then
+                  block_hash_arg="--block $(cat ${node_dir}/chain.snapshot.block_hash)"
               fi
               
               ${node} snapshot import ${snapshot_file} --data-dir ${node_data_dir} \
@@ -812,9 +809,6 @@ spec:
               node_data_dir="$node_dir/data"
               node="$bin_dir/octez-node"
               snapshot_file=${node_dir}/chain.snapshot
-              if [ -f ${node_dir}/chain.snapshot.block_hash ]; then
-                  block_hash=$(cat ${node_dir}/chain.snapshot.block_hash)
-              fi
               
               if [ ! -f ${snapshot_file} ]; then
                   echo "No snapshot to import."
@@ -830,8 +824,8 @@ spec:
               
               cp -v /etc/tezos/config.json ${node_data_dir}
               
-              if [ "${block_hash}" != "" ]; then
-                block_hash_arg="--block ${block_hash}"
+              if [ -f ${node_dir}/chain.snapshot.block_hash ]; then
+                  block_hash_arg="--block $(cat ${node_dir}/chain.snapshot.block_hash)"
               fi
               
               ${node} snapshot import ${snapshot_file} --data-dir ${node_data_dir} \

--- a/test/charts/private-chain.expect.yaml
+++ b/test/charts/private-chain.expect.yaml
@@ -105,7 +105,7 @@ data:
   ARCHIVE_TARBALL_URL: ""
   PREFER_TARBALLS: "false"
   SNAPSHOT_SOURCE: ""
-  OCTEZ_VERSION: "tezos/tezos:v14-release"
+  OCTEZ_VERSION: "tezos/tezos:v15-release"
   NODE_GLOBALS: |
     {
       "env": {}

--- a/test/charts/private-chain.expect.yaml
+++ b/test/charts/private-chain.expect.yaml
@@ -103,6 +103,9 @@ data:
   ROLLING_SNAPSHOT_URL: ""
   ROLLING_TARBALL_URL: ""
   ARCHIVE_TARBALL_URL: ""
+  PREFER_TARBALLS: "false"
+  SNAPSHOT_SOURCE: ""
+  OCTEZ_VERSION: "tezos/tezos:v14-release"
   NODE_GLOBALS: |
     {
       "env": {}

--- a/test/charts/private-chain.in.yaml
+++ b/test/charts/private-chain.in.yaml
@@ -72,9 +72,7 @@ activation:
     sc_rollup_max_available_messages: 1000000
 bootstrap_peers: []
 expected_proof_of_work: 0
-full_snapshot_url: null
-rolling_snapshot_url: null
-archive_tarball_url: null
+snapshot_source: null
 images:
   octez: 'tezos/tezos:v14-release'
 is_invitation: false

--- a/utils/Dockerfile
+++ b/utils/Dockerfile
@@ -1,4 +1,6 @@
-FROM python:3.9-alpine
+FROM python:3.10-alpine
+# TODO: update to 3.11 once the bug is fixed:
+# https://github.com/baking-bad/pytezos/issues/336
 ENV PYTHONUNBUFFERED=1
 
 #
@@ -14,7 +16,7 @@ RUN     PIP="pip --no-cache install"					\
   $APK_ADD --virtual .build-deps gcc python3-dev			\
   libffi-dev musl-dev make		\
   && $APK_ADD libsodium-dev libsecp256k1-dev gmp-dev			\
-  && $APK_ADD zeromq-dev						\
+  && $APK_ADD zeromq-dev findmnt						\
   && $PIP install base58 pynacl					\
   && $PIP install mnemonic pytezos requests				\
   && $PIP install pyblake2 pysodium flask \

--- a/utils/config-generator.py
+++ b/utils/config-generator.py
@@ -626,7 +626,7 @@ def create_node_snapshot_config_json(history_mode):
     """Create this node's snapshot config"""
 
     network_name = NETWORK_CONFIG.get("chain_name")
-    prefer_tarballs = os.environ["PREFER_TARBALLS"] == True
+    prefer_tarballs = os.environ["PREFER_TARBALLS"].lower() in ('true', '1', 't')
     artifact_type = "tarball" if prefer_tarballs else "tezos-snapshot"
     rolling_tarball_url = os.environ["ROLLING_TARBALL_URL"]
     full_tarball_url = os.environ["FULL_TARBALL_URL"]

--- a/utils/config-generator.py
+++ b/utils/config-generator.py
@@ -665,7 +665,10 @@ def create_node_snapshot_config_json(history_mode):
                 print(f"Error: history mode {history_mode} is not known.")
                 sys.exit(1)
 
-    octez_container_version = os.environ["OCTEZ_VERSION"]
+    if "images" in MY_POD_CLASS and "octez" in MY_POD_CLASS["images"]:
+        octez_container_version = MY_POD_CLASS["images"]["octez"]
+    else:
+        octez_container_version = os.environ["OCTEZ_VERSION"]
     snapshot_source = os.environ["SNAPSHOT_SOURCE"]
     if snapshot_source:
         try:

--- a/utils/config-generator.py
+++ b/utils/config-generator.py
@@ -668,8 +668,8 @@ def create_node_snapshot_config_json(history_mode):
     if "images" in MY_POD_CLASS and "octez" in MY_POD_CLASS["images"]:
         octez_container_version = MY_POD_CLASS["images"]["octez"]
     else:
-        octez_container_version = os.environ["OCTEZ_VERSION"]
-    snapshot_source = os.environ["SNAPSHOT_SOURCE"]
+        octez_container_version = os.environ.get("OCTEZ_VERSION")
+    snapshot_source = os.environ.get("SNAPSHOT_SOURCE")
     if snapshot_source:
         try:
             all_snapshots = requests.get(snapshot_source).json()
@@ -705,7 +705,7 @@ and octez version {octez_version}.
         ]
         if octez_version:
             matching_snapshots = [ s for s in matching_snapshots if  octez_version in s["tezos_version"] ]
-        matching_snapshots = sorted(matching_snapshots, key=lambda d: d["block_height"])
+        matching_snapshots = sorted(matching_snapshots, key=lambda d: d.get("block_height"))
 
         matching_snapshot = matching_snapshots[-1]
         return matching_snapshot

--- a/utils/config-generator.py
+++ b/utils/config-generator.py
@@ -674,10 +674,8 @@ def create_node_snapshot_config_json(history_mode):
         return {}
     try:
         octez_long_version = octez_container_version.split(":")[1]
-        octez_version_re = re.search(r"v\d\d", octez_long_version)
-        octez_version = None
-        if octez_version_re:
-            octez_version = octez_version_re.group().replace("v", "")
+        octez_version_re = re.search(r"v(\d+)", octez_long_version)
+        octez_version = octez_version_re and octez_version_re.group(1)
     except Exception:
         octez_version = None
 

--- a/utils/config-generator.py
+++ b/utils/config-generator.py
@@ -626,7 +626,7 @@ def create_node_snapshot_config_json(history_mode):
     """Create this node's snapshot config"""
 
     network_name = NETWORK_CONFIG.get("chain_name")
-    prefer_tarballs = os.environ["PREFER_TARBALLS"].lower() in ("true", "1", "t")
+    prefer_tarballs = os.environ.get("PREFER_TARBALLS").lower() in ("true", "1", "t")
     artifact_type = "tarball" if prefer_tarballs else "tezos-snapshot"
     rolling_tarball_url = os.environ.get("ROLLING_TARBALL_URL")
     full_tarball_url = os.environ.get("FULL_TARBALL_URL")

--- a/utils/config-generator.py
+++ b/utils/config-generator.py
@@ -160,12 +160,13 @@ def main():
         )
         print("Generated config.json :")
         print(node_config_json)
-        print("Generated snapshot_config.json :")
-        print(node_snapshot_config_json)
         with open("/etc/tezos/config.json", "w") as json_file:
             print(node_config_json, file=json_file)
-        with open("/var/tezos/snapshot_config.json", "w") as json_file:
-            print(node_snapshot_config_json, file=json_file)
+        if node_snapshot_config:
+            print("Generated snapshot_config.json :")
+            print(node_snapshot_config_json)
+            with open("/var/tezos/snapshot_config.json", "w") as json_file:
+                print(node_snapshot_config_json, file=json_file)
 
 
 # If NETWORK_CONFIG["genesis"]["block"] hasn't been specified, we generate a

--- a/utils/config-generator.py
+++ b/utils/config-generator.py
@@ -698,15 +698,15 @@ and octez version {octez_version}.
     matching_snapshots = [
         s
         for s in all_snapshots
-        if s["history_mode"] == history_mode
-        and s["artifact_type"] == artifact_type
-        and s["chain_name"] == network_name
+        if s.get("history_mode") == history_mode
+        and s.get("artifact_type") == artifact_type
+        and s.get("chain_name") == network_name
     ]
     if octez_version:
         matching_snapshots = [
-            s for s in matching_snapshots if octez_version in s["tezos_version"]
+            s for s in matching_snapshots if octez_version in s.get("tezos_version")
         ]
-    matching_snapshots = sorted(matching_snapshots, key=lambda d: d.get("block_height"))
+    matching_snapshots = sorted(matching_snapshots, key=lambda s: s.get("block_height"))
 
     return matching_snapshots[-1] if len(matching_snapshots) else None
 

--- a/utils/config-generator.py
+++ b/utils/config-generator.py
@@ -5,6 +5,7 @@ import os
 import re
 import requests
 import socket
+import sys
 from grp import getgrnam
 from hashlib import blake2b
 from pathlib import Path
@@ -661,7 +662,8 @@ def create_node_snapshot_config_json(history_mode):
                     return {"url": archive_tarball_url, "artifact_type": "tarball"}
                 return
             case _:
-                return
+                print(f"Error: history mode {history_mode} is not known.")
+                sys.exit(1)
 
     octez_container_version = os.environ["OCTEZ_VERSION"]
     snapshot_source = os.environ["SNAPSHOT_SOURCE"]

--- a/utils/config-generator.py
+++ b/utils/config-generator.py
@@ -625,7 +625,6 @@ def create_node_snapshot_config_json(history_mode):
     """Create this node's snapshot config"""
 
     network_name = NETWORK_CONFIG.get("chain_name")
-    snapshot_source = os.environ["SNAPSHOT_SOURCE"]
     prefer_tarballs = os.environ["PREFER_TARBALLS"] == True
     artifact_type = "tarball" if prefer_tarballs else "tezos-snapshot"
     rolling_tarball_url = os.environ["ROLLING_TARBALL_URL"]
@@ -665,6 +664,7 @@ def create_node_snapshot_config_json(history_mode):
                 return {}
 
     octez_container_version = os.environ["OCTEZ_VERSION"]
+    snapshot_source = os.environ["SNAPSHOT_SOURCE"]
     if snapshot_source:
         try:
             all_snapshots = requests.get(snapshot_source).json()

--- a/utils/config-generator.py
+++ b/utils/config-generator.py
@@ -628,11 +628,11 @@ def create_node_snapshot_config_json(history_mode):
     network_name = NETWORK_CONFIG.get("chain_name")
     prefer_tarballs = os.environ["PREFER_TARBALLS"].lower() in ('true', '1', 't')
     artifact_type = "tarball" if prefer_tarballs else "tezos-snapshot"
-    rolling_tarball_url = os.environ["ROLLING_TARBALL_URL"]
-    full_tarball_url = os.environ["FULL_TARBALL_URL"]
-    archive_tarball_url = os.environ["ARCHIVE_TARBALL_URL"]
-    rolling_snapshot_url = os.environ["ROLLING_SNAPSHOT_URL"]
-    full_snapshot_url = os.environ["FULL_SNAPSHOT_URL"]
+    rolling_tarball_url = os.environ.get("ROLLING_TARBALL_URL")
+    full_tarball_url = os.environ.get("FULL_TARBALL_URL")
+    archive_tarball_url = os.environ.get("ARCHIVE_TARBALL_URL")
+    rolling_snapshot_url = os.environ.get("ROLLING_SNAPSHOT_URL")
+    full_snapshot_url = os.environ.get("FULL_SNAPSHOT_URL")
     if (
         rolling_tarball_url
         or full_tarball_url

--- a/utils/config-generator.py
+++ b/utils/config-generator.py
@@ -151,7 +151,7 @@ def main():
             indent=2,
         )
         node_snapshot_config = create_node_snapshot_config_json(
-            NETWORK_CONFIG.get("chain_name"), node_config["shell"]["history_mode"]
+            node_config["shell"]["history_mode"]
         )
         node_snapshot_config_json = json.dumps(
             node_snapshot_config,
@@ -621,9 +621,10 @@ def create_node_config_json(
     return node_config
 
 
-def create_node_snapshot_config_json(network_name, history_mode):
+def create_node_snapshot_config_json(history_mode):
     """Create this node's snapshot config"""
 
+    network_name = NETWORK_CONFIG.get("chain_name")
     snapshot_source = os.environ["SNAPSHOT_SOURCE"]
     prefer_tarballs = os.environ["PREFER_TARBALLS"] == True
     artifact_type = "tarball" if prefer_tarballs else "tezos-snapshot"

--- a/utils/config-generator.py
+++ b/utils/config-generator.py
@@ -704,7 +704,7 @@ and octez version {octez_version}.
     ]
     if octez_version:
         matching_snapshots = [
-            s for s in matching_snapshots if octez_version in s.get("tezos_version")
+            s for s in matching_snapshots if octez_version in s.get("tezos_version", "")
         ]
     matching_snapshots = sorted(matching_snapshots, key=lambda s: s.get("block_height"))
 

--- a/utils/config-generator.py
+++ b/utils/config-generator.py
@@ -625,7 +625,7 @@ def create_node_snapshot_config_json(network_name, history_mode):
     """Create this node's snapshot config"""
 
     snapshot_source = os.environ["SNAPSHOT_SOURCE"]
-    prefer_tarballs = os.environ["PREFER_TARBALLS"] == "true"
+    prefer_tarballs = os.environ["PREFER_TARBALLS"] == True
     artifact_type = "tarball" if prefer_tarballs else "tezos-snapshot"
     rolling_tarball_url = os.environ["ROLLING_TARBALL_URL"]
     full_tarball_url = os.environ["FULL_TARBALL_URL"]

--- a/utils/config-generator.py
+++ b/utils/config-generator.py
@@ -697,8 +697,9 @@ and octez version {octez_version}.
             if s["history_mode"] == history_mode
             and s["artifact_type"] == artifact_type
             and s["chain_name"] == network_name
-            and octez_version in s["tezos_version"]
         ]
+        if octez_version:
+            matching_snapshots = [ s for s in matching_snapshots if  octez_version in s["tezos_version"] ]
         matching_snapshots = sorted(matching_snapshots, key=lambda d: d["block_height"])
 
         matching_snapshot = matching_snapshots[-1]

--- a/utils/config-generator.py
+++ b/utils/config-generator.py
@@ -649,29 +649,30 @@ def create_node_snapshot_config_json(history_mode):
                         "url": rolling_snapshot_url,
                         "artifact_type": "tezos-snapshot",
                     }
-                return {}
+                return
             case "full":
                 if full_tarball_url:
                     return {"url": full_tarball_url, "artifact_type": "tarball"}
                 elif full_snapshot_url:
                     return {"url": full_snapshot_url, "artifact_type": "tezos-snapshot"}
-                return {}
+                return
             case "archive":
                 if archive_tarball_url:
                     return {"url": archive_tarball_url, "artifact_type": "tarball"}
-                return {}
+                return
             case _:
-                return {}
+                return
 
     octez_container_version = os.environ["OCTEZ_VERSION"]
     snapshot_source = os.environ["SNAPSHOT_SOURCE"]
     if snapshot_source:
         try:
             all_snapshots = requests.get(snapshot_source).json()
-        except Exception:
-            return {}
+        except Exception as e:
+            print(f"Error while fetching {snapshot_source}: {e}")
+            return
     else:
-        return {}
+        return
     try:
         octez_long_version = octez_container_version.split(":")[1]
         octez_version_re = re.search(r"v(\d+)", octez_long_version)

--- a/utils/config-generator.py
+++ b/utils/config-generator.py
@@ -695,22 +695,18 @@ and octez version {octez_version}.
     """
     )
     # find snapshot matching all the requested fields
-    try:
-        matching_snapshots = [
-            s
-            for s in all_snapshots
-            if s["history_mode"] == history_mode
-            and s["artifact_type"] == artifact_type
-            and s["chain_name"] == network_name
-        ]
-        if octez_version:
-            matching_snapshots = [ s for s in matching_snapshots if  octez_version in s["tezos_version"] ]
-        matching_snapshots = sorted(matching_snapshots, key=lambda d: d.get("block_height"))
+    matching_snapshots = [
+        s
+        for s in all_snapshots
+        if s["history_mode"] == history_mode
+        and s["artifact_type"] == artifact_type
+        and s["chain_name"] == network_name
+    ]
+    if octez_version:
+        matching_snapshots = [ s for s in matching_snapshots if  octez_version in s["tezos_version"] ]
+    matching_snapshots = sorted(matching_snapshots, key=lambda d: d.get("block_height"))
 
-        matching_snapshot = matching_snapshots[-1]
-        return matching_snapshot
-    except Exception:
-        return None
+    return matching_snapshots[-1] if len(matching_snapshots) else None
 
 
 if __name__ == "__main__":

--- a/utils/config-generator.py
+++ b/utils/config-generator.py
@@ -626,7 +626,7 @@ def create_node_snapshot_config_json(history_mode):
     """Create this node's snapshot config"""
 
     network_name = NETWORK_CONFIG.get("chain_name")
-    prefer_tarballs = os.environ["PREFER_TARBALLS"].lower() in ('true', '1', 't')
+    prefer_tarballs = os.environ["PREFER_TARBALLS"].lower() in ("true", "1", "t")
     artifact_type = "tarball" if prefer_tarballs else "tezos-snapshot"
     rolling_tarball_url = os.environ.get("ROLLING_TARBALL_URL")
     full_tarball_url = os.environ.get("FULL_TARBALL_URL")
@@ -703,7 +703,9 @@ and octez version {octez_version}.
         and s["chain_name"] == network_name
     ]
     if octez_version:
-        matching_snapshots = [ s for s in matching_snapshots if  octez_version in s["tezos_version"] ]
+        matching_snapshots = [
+            s for s in matching_snapshots if octez_version in s["tezos_version"]
+        ]
     matching_snapshots = sorted(matching_snapshots, key=lambda d: d.get("block_height"))
 
     return matching_snapshots[-1] if len(matching_snapshots) else None

--- a/utils/config-generator.py
+++ b/utils/config-generator.py
@@ -626,7 +626,7 @@ def create_node_snapshot_config_json(history_mode):
     """Create this node's snapshot config"""
 
     network_name = NETWORK_CONFIG.get("chain_name")
-    prefer_tarballs = os.environ.get("PREFER_TARBALLS").lower() in ("true", "1", "t")
+    prefer_tarballs = os.environ.get("PREFER_TARBALLS", "").lower() in ("true", "1", "t")
     artifact_type = "tarball" if prefer_tarballs else "tezos-snapshot"
     rolling_tarball_url = os.environ.get("ROLLING_TARBALL_URL")
     full_tarball_url = os.environ.get("FULL_TARBALL_URL")

--- a/utils/snapshot-downloader.sh
+++ b/utils/snapshot-downloader.sh
@@ -57,6 +57,7 @@ download() {
     fi
   fi
 }
+
 if [ "${artifact_type}" == "tezos-snapshot" ]; then
   echo "Downloading $artifact_url"
   echo '{ "version": "0.0.4" }' > "$node_dir/version.json"

--- a/utils/snapshot-downloader.sh
+++ b/utils/snapshot-downloader.sh
@@ -41,7 +41,7 @@ download() {
     free_space=$(findmnt -bno size -T ${data_dir})
     echo "Free space available in filesystem: ${free_space}" >&2
     if [ "${filesize_bytes}" -gt "${free_space}" ]; then
-      echo "Error: not enough disk space available to download artifact." >&2
+      echo "Error: not enough disk space available (${free_space} bytes) to download artifact of size ${filesize_bytes} bytes." >&2
       touch ${data_dir}/disk_space_failed
       return 1
     else

--- a/utils/snapshot-downloader.sh
+++ b/utils/snapshot-downloader.sh
@@ -42,7 +42,7 @@ download() {
     echo "Free space available in filesystem: ${free_space}" >&2
     if [ "${filesize_bytes}" -gt "${free_space}" ]; then
       echo "Error: not enough disk space available to download artifact." >&2
-      exit 1
+      touch ${data_dir}/disk_space_failed
     else
       echo "There is sufficient free space to download the artifact of size ${filesize_bytes}." >&2
     fi
@@ -80,6 +80,10 @@ elif [ "${artifact_type}" == "tarball" ]; then
     rm -rvf "${data_dir}/sha256sum_failed"
     exit 1
   fi
+fi
+if [ -f "${data_dir}/disk_space_failed" ]; then
+  rm -rvf "${data_dir}/disk_space_failed"
+  exit 1
 fi
 
 chown -R 1000 "$data_dir"

--- a/utils/snapshot-downloader.sh
+++ b/utils/snapshot-downloader.sh
@@ -19,7 +19,7 @@ fi
 
 echo "Did not find a pre-existing blockchain."
 
-if [ "$(cat ${data_dir}/snapshot_config.json)" == "null" ]; then
+if [ ! -f ${data_dir}/snapshot_config.json ]; then
   echo "No snapshot config found, nothing to do."
   exit 0
 fi

--- a/utils/snapshot-downloader.sh
+++ b/utils/snapshot-downloader.sh
@@ -53,6 +53,7 @@ download() {
     if [ "${sha256}" != "$(cat ${snapshot_file}.sha256sum | head -c 64)" ]; then
       echo "Error: sha256 checksum of the downloaded file did not match checksum from metadata file." >&2
       touch ${data_dir}/sha256sum_failed
+      return 1
     else
       echo "Snapshot sha256sum check successful." >&2
     fi

--- a/utils/snapshot-downloader.sh
+++ b/utils/snapshot-downloader.sh
@@ -19,48 +19,55 @@ fi
 
 echo "Did not find a pre-existing blockchain."
 
-my_nodes_history_mode=$(< /etc/tezos/config.json jq -r "
-				.shell.history_mode
-				|if type == \"object\" then
-					(keys|.[0])
-				 else .
-				 end")
-
-echo "My nodes history mode: '$my_nodes_history_mode'"
-
-snapshot_url=""
-tarball_url=""
-case "$my_nodes_history_mode" in
-  full)     snapshot_url="$FULL_SNAPSHOT_URL"
-            tarball_url="$FULL_TARBALL_URL";;
-
-  rolling)  snapshot_url="$ROLLING_SNAPSHOT_URL"
-            tarball_url="$ROLLING_TARBALL_URL";;
-
-  archive)  tarball_url="$ARCHIVE_TARBALL_URL";;
-
-  *)        echo "Invalid node history mode: '$my_nodes_history_mode'"
-            exit 1;;
-esac
-
-if [ -z "$snapshot_url" ] && [ -z "$tarball_url" ]; then
-  echo "ERROR: No snapshot or tarball url specified."
-  exit 1
+if [ "$(cat ${data_dir}/snapshot_config.json)" == "null" ]; then
+  echo "No snapshot config found, nothing to do."
+  exit 0
 fi
 
-if [ -n "$snapshot_url" ] && [ -n "$tarball_url" ]; then
-  echo "ERROR: Either only a snapshot or tarball url may be specified per Tezos node history mode."
-fi
+echo "Tezos snapshot config is:"
+cat ${data_dir}/snapshot_config.json
 
+artifact_url=$(cat ${data_dir}/snapshot_config.json | jq -r '.url')
+artifact_type=$(cat ${data_dir}/snapshot_config.json | jq -r '.artifact_type')
 mkdir -p "$node_data_dir"
 
-if [ -n "$snapshot_url" ]; then
-  echo "Downloading $snapshot_url"
+download() {
+  # Smart Downloading function. When relevant metadata is accessible, it:
+  # * checks that there is enough space to download the file
+  # * verifies the sha256sum
+  filesize_bytes=$(cat ${data_dir}/snapshot_config.json | jq -r '.filesize_bytes // empty')
+  sha256=$(cat ${data_dir}/snapshot_config.json | jq -r '.sha256 // empty')
+  if [ ! -z "${filesize_bytes}" ]; then
+    free_space=$(findmnt -bno size -T ${data_dir})
+    echo "Free space available in filesystem: ${free_space}" >&2
+    if [ "${filesize_bytes}" -gt "${free_space}" ]; then
+      echo "Error: not enough disk space available to download artifact." >&2
+      exit 1
+    else
+      echo "There is sufficient free space to download the artifact of size ${filesize_bytes}." >&2
+    fi
+  fi
+  curl -LfsS $1 | tee >(sha256sum > ${snapshot_file}.sha256sum)
+  if [ ! -z "${sha256}" ]; then
+    if [ "${sha256}" != "$(cat ${snapshot_file}.sha256sum | head -c 64)" ]; then
+      echo "Error: sha256 checksum of the downloaded file did not match checksum from metadata file." >&2
+      exit 1
+    else
+      echo "Snapshot sha256sum check successful." >&2
+    fi
+  fi
+}
+if [ "${artifact_type}" == "tezos-snapshot" ]; then
+  echo "Downloading $artifact_url"
   echo '{ "version": "0.0.4" }' > "$node_dir/version.json"
-  curl -LfsS -o "$snapshot_file" "$snapshot_url"
-elif [ -n "$tarball_url" ]; then
-  echo "Downloading and extracting tarball from $tarball_url"
-  curl -LfsS "$tarball_url" | lz4 -d | tar -x -C "$data_dir"
+  block_hash=$(cat ${data_dir}/snapshot_config.json | jq -r '.block_hash // empty')
+  download "$artifact_url" > "$snapshot_file"
+  if [ ! -z "${block_hash}" ]; then
+    echo ${block_hash} > ${snapshot_file}.block_hash
+  fi
+elif [ "${artifact_type}" == "tarball" ]; then
+  echo "Downloading and extracting tarball from $artifact_url"
+  download "$artifact_url" | lz4 -d | tar -x -C "$data_dir"
 fi
 
 chown -R 1000 "$data_dir"

--- a/utils/snapshot-downloader.sh
+++ b/utils/snapshot-downloader.sh
@@ -66,6 +66,7 @@ if [ "${artifact_type}" == "tezos-snapshot" ]; then
   download "$artifact_url" > "$snapshot_file"
   if [ -f "${data_dir}/sha256sum_failed" ]; then
     # sha256 failure
+    rm -rvf ${snapshot_file}
     rm -rvf "${data_dir}/sha256sum_failed"
     exit 1
   fi

--- a/utils/snapshot-downloader.sh
+++ b/utils/snapshot-downloader.sh
@@ -43,6 +43,7 @@ download() {
     if [ "${filesize_bytes}" -gt "${free_space}" ]; then
       echo "Error: not enough disk space available to download artifact." >&2
       touch ${data_dir}/disk_space_failed
+      return 1
     else
       echo "There is sufficient free space to download the artifact of size ${filesize_bytes}." >&2
     fi


### PR DESCRIPTION
This introduces under the hood "magic" to download the right snapshot for you, when using default values.

There was a previous attempt #394, however since then we have made some progress in formalizing the metadata at xtz-shots.io, to the point where it makes sense to introduce these changes instead.

The metadata file https://xtz-shots.io/tezos-snapshots.json is intended to become some sort of standard across ecosystem snapshot providers.

It provides a flat list of snapshots across tezos networks, containing size in bytes and sha256sum.

We introduce a new value `snapshot_source` which is defaulting to the xtz-shots metadata URL. I hope marigold will provide one such file soon as well.

When this file is set, config-generator will download it, and find the right snapshot, based on the network name and the octez version. It will then pass it to the node pods for download.

We also introduce `prefer_tarballs` which will make the nodes download a tarball instead of a snapshot. This defaults to False to preserve today's behavior.

The variables `full_snapshot_url` `archive_tarball_url` etc... still exist. They used to have default set to mainnet URLs from xtz-shots, but they default to null now.

If you set these variables, they will override the metadata behavior that we are introducing. As before, you can't set a value for snapshot and tarball of same history mode at the same time, or helm will error.

When using the new method, two new behaviors are introduced:

1. snapshot-downloader verifies the free space on the filesystem, and does not attempt to download if it is insufficient
1. after downloading, it will check the sha256sum against the one in metadata.

Now, our "quick start" guide will become more compelling: with just one line of helm, it will be possible to start a mainnet node, a ghostnet node, or any network on xtz-shots.

Test:

These 4 values yaml are provided as reference.

I tested them all on limanet (because artifacst are small and fast).

When it's merged and released, the `tezos_k8s_images` value can go and only `node_config_network:chain_name` needs to be set.

```
/# starts a limanet rolling node, downloads a snapshot, verifies checksum and unpacks it
tezos_k8s_images:
  utils: ghcr.io/oxheadalpha/tezos-k8s-utils:snapshot_metadata
node_config_network:
  chain_name: limanet
```

```
/# starts a limanet rolling node, downloads a tarball, verifies checksum and unpacks it
tezos_k8s_images:
  utils: ghcr.io/oxheadalpha/tezos-k8s-utils:snapshot_metadata
node_config_network:
  chain_name: limanet
prefer_tarballs: true
```

```
/# verify that old method of downloading tarball still works
tezos_k8s_images:
  utils: ghcr.io/oxheadalpha/tezos-k8s-utils:snapshot_metadata
node_config_network:
  chain_name: limanet
rolling_tarball_url: https://limanet.xtz-shots.io/rolling-tarball
rolling_snapshot_url: null
```

```
/# verify that old method of downloading snapshot still works
tezos_k8s_images:
  utils: ghcr.io/oxheadalpha/tezos-k8s-utils:snapshot_metadata
node_config_network:
  chain_name: limanet
rolling_tarball_url: null
rolling_snapshot_url: https://limanet.xtz-shots.io/rolling
```

I also tried a private chain with mkchain with no parameters. it works

I am updating the python version to 3.10 in utils because I wanted to use python's new `case` statement. I tried 3.11 but pytezos is broken, I opened a ticket and referenced it in the source code.