### PR TITLE
Add rpc service port for tezos node

### DIFF
--- a/charts/tezos/templates/static.yaml
+++ b/charts/tezos/templates/static.yaml
@@ -22,6 +22,8 @@ metadata:
     appType: tezos-node
 spec:
   ports:
+    - port: 8732
+      name: rpc
     - port: 9732
       name: p2p
     - port: 9932

--- a/test/charts/mainnet.expect.yaml
+++ b/test/charts/mainnet.expect.yaml
@@ -89,6 +89,8 @@ metadata:
     appType: tezos-node
 spec:
   ports:
+    - port: 8732
+      name: rpc
     - port: 9732
       name: p2p
     - port: 9932

--- a/test/charts/mainnet2.expect.yaml
+++ b/test/charts/mainnet2.expect.yaml
@@ -128,6 +128,8 @@ metadata:
     appType: tezos-node
 spec:
   ports:
+    - port: 8732
+      name: rpc
     - port: 9732
       name: p2p
     - port: 9932
@@ -146,6 +148,8 @@ metadata:
     appType: tezos-node
 spec:
   ports:
+    - port: 8732
+      name: rpc
     - port: 9732
       name: p2p
     - port: 9932

--- a/test/charts/private-chain.expect.yaml
+++ b/test/charts/private-chain.expect.yaml
@@ -240,6 +240,8 @@ metadata:
     appType: tezos-node
 spec:
   ports:
+    - port: 8732
+      name: rpc
     - port: 9732
       name: p2p
     - port: 9932
@@ -258,6 +260,8 @@ metadata:
     appType: tezos-node
 spec:
   ports:
+    - port: 8732
+      name: rpc
     - port: 9732
       name: p2p
     - port: 9932
@@ -276,6 +280,8 @@ metadata:
     appType: tezos-node
 spec:
   ports:
+    - port: 8732
+      name: rpc
     - port: 9732
       name: p2p
     - port: 9932
@@ -294,6 +300,8 @@ metadata:
     appType: tezos-node
 spec:
   ports:
+    - port: 8732
+      name: rpc
     - port: 9732
       name: p2p
     - port: 9932


### PR DESCRIPTION
Currently rpc port is export from a NodePort service with a selector, this is not that
flexible in some use scenarios. 

This commit exports the rpc port for tezos node service with ClusterIP, this allows more flexible service route for k8s ingress, e.g. backend rpc services can be directed based on uri path to different tezos node services.