### PR TITLE
v15+lima default for tezos-k8s

### DIFF
--- a/charts/snapshotEngine/README.md
+++ b/charts/snapshotEngine/README.md
@@ -320,12 +320,12 @@ Overview of functionality of containers in Kubernetes Job Pods.
 
 ##### init-tezos-filesystem Container
 
-In order for the storage to be imported successfully to a new node, the storage needs to be initialized by the `tezos-node` application.
+In order for the storage to be imported successfully to a new node, the storage needs to be initialized by the `octez-node` application.
 
 This container performs the following steps -
 
 1. Chowns the history-mode-snapshot-cache-volume to 100 so subsequent containers can access files created in them.
-2. Sets a trap so that we can exit this container after 2 minutes.  `tezos-node` does not provide exit criteria if there is an error. Around 20%-40% of the time there will be an error because the EC2 instance would normally need to be shut down before an EBS snapshot is taken. With Kubernetes this is not possible, so we time the filesystem initialization and kill it if it takes longer than 2 minutes.
+2. Sets a trap so that we can exit this container after 2 minutes.  `octez-node` does not provide exit criteria if there is an error. Around 20%-40% of the time there will be an error because the EC2 instance would normally need to be shut down before an EBS snapshot is taken. With Kubernetes this is not possible, so we time the filesystem initialization and kill it if it takes longer than 2 minutes.
 3. Runs a headless Tezos RPC endpoint to initialize the storage.
 4. Waits until RPC is available.
 5. Writes `BLOCK_HASH`, `BLOCK_HEIGHT`, and `BLOCK_TIME` for later use to snapshot cache.
@@ -338,8 +338,8 @@ This container performs the following steps -
 
 1. Chowns the history-mode-snapshot-cache-volume and rolling-tarball-restore volume to 100 so subsequent containers can access files created in them.
 2. Gets network name from the namespace.
-3. Performs a `tezos-node config init` on our restored snapshot storage.
-4. Performs a `tezos-node snapshot export` to create the `.rolling` file to be uploaded later.
+3. Performs a `octez-node config init` on our restored snapshot storage.
+4. Performs a `octez-node snapshot export` to create the `.rolling` file to be uploaded later.
 5. Restores this new snapshot to the `rolling-tarball-restore` PVC to later create the rolling tarball.
 6. Creates a file to alert the next job that the rolling snapshot is currently being created and tells it to wait.
 

--- a/charts/snapshotEngine/values.yaml
+++ b/charts/snapshotEngine/values.yaml
@@ -1,9 +1,9 @@
 tezos_k8s_images:
   snapshotEngine: ghcr.io/oxheadalpha/tezos-k8s-snapshotengine:master
 
-# the tezos version used to run `tezos-node snapshot import/export`
+# the tezos version used to run `octez-node snapshot import/export`
 images:
-  octez: tezos/tezos:v14-release
+  octez: tezos/tezos:v15-release
 
 # snapshotEngine containers interact with the kubernetes control
 # plane to create volume snapshots. This requires a special IAM role

--- a/charts/tezos/scripts/baker.sh
+++ b/charts/tezos/scripts/baker.sh
@@ -22,7 +22,7 @@ EOF
 fi
 extra_args="--votefile ${per_block_vote_file}"
 
-tezos_version=$(tezos-client --version | sed -e 's/ //g')
+tezos_version=$(octez-client --version | sed -e 's/ //g')
 if [[ "$tezos_version" == *"13.0"* ]]; then
   # version 13 of octez mandates CLI flag as well as vote file
   extra_args="$extra_args --liquidity-baking-toggle-vote on"
@@ -30,10 +30,10 @@ fi
 
 my_baker_account="$(cat /etc/tezos/baker-account )"
 
-CLIENT="$TEZ_BIN/tezos-client -d $CLIENT_DIR"
+CLIENT="$TEZ_BIN/octez-client -d $CLIENT_DIR"
 CMD="$TEZ_BIN/tezos-baker-$proto_command -d $CLIENT_DIR"
 
-# ensure we can run tezos-client commands without specifying client dir
+# ensure we can run octez-client commands without specifying client dir
 ln -s /var/tezos/client /home/tezos/.tezos-client
 
 while ! $CLIENT rpc get chains/main/blocks/head; do

--- a/charts/tezos/scripts/chain-initiator.sh
+++ b/charts/tezos/scripts/chain-initiator.sh
@@ -1,4 +1,4 @@
-CLIENT="/usr/local/bin/tezos-client --endpoint http://tezos-node-rpc:8732"
+CLIENT="/usr/local/bin/octez-client --endpoint http://tezos-node-rpc:8732"
 
 until $CLIENT rpc get /chains/main/blocks/head/header | grep '"level":'; do
     sleep 2

--- a/charts/tezos/scripts/config-init.sh
+++ b/charts/tezos/scripts/config-init.sh
@@ -4,7 +4,7 @@ mkdir -p /etc/tezos/data
 #
 # This is my comment.
 
-/usr/local/bin/tezos-node config init		\
+/usr/local/bin/octez-node config init		\
     --config-file /etc/tezos/data/config.json	\
     --data-dir /etc/tezos/data			\
     --network $CHAIN_NAME

--- a/charts/tezos/scripts/octez-node.sh
+++ b/charts/tezos/scripts/octez-node.sh
@@ -2,15 +2,15 @@ set -x
 
 set
 
-# ensure we can run tezos-client commands without specifying client dir
+# ensure we can run octez-client commands without specifying client dir
 ln -s /var/tezos/client /home/tezos/.tezos-client
 #
 # Not every error is fatal on start.  In particular, with zerotier,
-# the listen-addr may not yet be bound causing tezos-node to fail.
+# the listen-addr may not yet be bound causing octez-node to fail.
 # So, we try a few times with increasing delays:
 
 for d in 1 1 5 10 20 60 120; do
-	/usr/local/bin/tezos-node run				\
+	/usr/local/bin/octez-node run				\
 			--bootstrap-threshold 0			\
 			--config-file /etc/tezos/config.json
 	sleep $d

--- a/charts/tezos/scripts/snapshot-importer.sh
+++ b/charts/tezos/scripts/snapshot-importer.sh
@@ -4,7 +4,7 @@ bin_dir="/usr/local/bin"
 data_dir="/var/tezos"
 node_dir="$data_dir/node"
 node_data_dir="$node_dir/data"
-node="$bin_dir/tezos-node"
+node="$bin_dir/octez-node"
 snapshot_file=${node_dir}/chain.snapshot
 
 if [ -d ${node_data_dir}/context ]; then

--- a/charts/tezos/scripts/upgrade-storage.sh
+++ b/charts/tezos/scripts/upgrade-storage.sh
@@ -5,4 +5,4 @@ then
   printf "No context in data dir found, probably initial start, doing nothing."
   exit 0
 fi
-tezos-node upgrade storage --data-dir /var/tezos/node/data
+octez-node upgrade storage --data-dir /var/tezos/node/data

--- a/charts/tezos/templates/_helpers.tpl
+++ b/charts/tezos/templates/_helpers.tpl
@@ -70,7 +70,7 @@
 {{- end }}
 
 {{/*
-  Checks if we need to run tezos-node config init to help config-generator
+  Checks if we need to run octez-node config init to help config-generator
   obtain the appropriate parameters to run a network. If there are no genesis
   params, we are dealing with a public network and want its default config.json
   to be created. If we are dealing with a custom chain, we validate that the

--- a/charts/tezos/templates/nodes.yaml
+++ b/charts/tezos/templates/nodes.yaml
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       labels:
-        appType: tezos-node
+        appType: octez-node
         node_class: {{ $.node_class }}
       {{- if has "baker" $.node_vals.runs }}
         baking_node: "true"

--- a/charts/tezos/templates/servicemonitor.yaml
+++ b/charts/tezos/templates/servicemonitor.yaml
@@ -13,5 +13,5 @@ spec:
     path: /metrics
   selector:
     matchLabels:
-      appType: tezos-node
+      appType: octez-node
 {{- end }}

--- a/charts/tezos/templates/static.yaml
+++ b/charts/tezos/templates/static.yaml
@@ -7,7 +7,7 @@ spec:
   ports:
     - port: 8732
       name: rpc
-  {{- with .Values.services.tezos_node_rpc.selector | default (dict "appType" "tezos-node") }}
+  {{- with .Values.services.tezos_node_rpc.selector | default (dict "appType" "octez-node") }}
   selector:
     {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -19,7 +19,7 @@ kind: Service
 metadata:
   name: {{ $key }}
   labels:
-    appType: tezos-node
+    appType: octez-node
 spec:
   ports:
     - port: 9732

--- a/charts/tezos/values.yaml
+++ b/charts/tezos/values.yaml
@@ -8,7 +8,7 @@ is_invitation: false
 
 # Images not part of the tezos-k8s repo go here
 images:
-  octez: tezos/tezos:v14-release
+  octez: tezos/tezos:v15-release
 # Images that are part of the tezos-k8s repo go here with 'dev' tag
 tezos_k8s_images:
   utils: ghcr.io/oxheadalpha/tezos-k8s-utils:master
@@ -101,7 +101,7 @@ should_generate_unsafe_deterministic_data: false
 #
 # Params at the statefulset level:
 # - "config": The "config" property should mimic the structure of a node's
-#             config.json. Run `tezos-node config --help` for more info.
+#             config.json. Run `octez-node config --help` for more info.
 #             If present at the statefulset level, it overrides it in
 #             node_globals.
 # - "env": a dictionary of containers mapped to a dictionary of env
@@ -284,7 +284,7 @@ bootstrap_peers: []
 expected_proof_of_work: 26
 
 ## Create a custom network using a config structure that is similar to a node's
-## config.json. Run `tezos-node config --help` for more info.
+## config.json. Run `octez-node config --help` for more info.
 ## Note that the genesis block hash will be deterministically generated from
 ## the chain name if omitted.
 ##
@@ -300,7 +300,7 @@ expected_proof_of_work: 26
 #
 ## To join a public network you may set `chain_name` in one of two ways:
 ## - Specify the name of the network which must be recognized by the
-##   tezos-node binary of the Octez image being used.
+##   octez-node binary of the Octez image being used.
 ## - Pass a url that returns the config.json of the network. Example:
 ##   "https://teztnets.xyz/mondaynet". It is helpful for running
 ##   testnets and shouldn't be needed in general.
@@ -327,7 +327,7 @@ protocols:
   ##   "on" and "off" must be between quotes.
   ## Note that we are not providing default votes since every baker needs
   ## to make an explicit educated choice on every toggle.
-  - command: 014-PtKathma
+  - command: PtLimaPt
     vote: {}
   # - command: alpha
   #   vote:
@@ -339,7 +339,7 @@ protocols:
 ## after chain activation.
 ##
 # activation:
-#  protocol_hash: PtKathmankSpLLDALzWw7CGD2j2MtyveTwboEYokqUCP4a1LxMg
+#  protocol_hash: PtLimaPtLMwfNinJi9rCfDPWea8dFgTZ1MeJ9f1m2SRic6ayiwW
 #  protocol_parameters:
 #    preserved_cycles: 3
 #    blocks_per_cycle: 8
@@ -349,7 +349,7 @@ protocols:
 #    hard_gas_limit_per_operation: '1040000'
 #    hard_gas_limit_per_block: '5200000'
 #    proof_of_work_threshold: '-1'
-#    tokens_per_roll: '8000000000'
+#    minimal_stake: '6000000000'
 #    seed_nonce_revelation_tip: '125000'
 #    baking_reward_fixed_portion: '10000000'
 #    baking_reward_bonus_per_slot: '4286'
@@ -361,7 +361,6 @@ protocols:
 #    quorum_min: 2000
 #    min_proposal_quorum: 500
 #    liquidity_baking_subsidy: '2500000'
-#    liquidity_baking_sunset_level: 10000000
 #    liquidity_baking_toggle_ema_threshold: 100000
 #    max_operations_time_to_live: 120
 #    minimal_block_delay: "5"
@@ -380,11 +379,12 @@ protocols:
 #    cache_script_size: 100000000
 #    cache_stake_distribution_cycles: 8
 #    cache_sampler_state_cycles: 8
+#    nonce_revelation_threshold: 4
+#    vdf_difficulty: '100000'
 #    tx_rollup_enable: true
 #    tx_rollup_origination_size: 4000
 #    tx_rollup_hard_size_limit_per_inbox: 500000
 #    tx_rollup_hard_size_limit_per_message: 5000
-#    tx_rollup_max_withdrawals_per_batch: 15
 #    tx_rollup_commitment_bond: "10000000000"
 #    tx_rollup_finality_period: 10
 #    tx_rollup_max_inboxes_count: 15
@@ -392,13 +392,34 @@ protocols:
 #    tx_rollup_max_messages_per_inbox: 1010
 #    tx_rollup_max_commitments_count: 30
 #    tx_rollup_cost_per_byte_ema_factor: 120
+#    tx_rollup_max_withdrawals_per_batch: 15
 #    tx_rollup_max_ticket_payload_size: 2048
 #    tx_rollup_rejection_max_proof_size: 30000
-#    tx_rollup_sunset_level: 17280
-#    sc_rollup_enable: false
+#    tx_rollup_sunset_level: 10000000
+#    dal_parametric:
+#      feature_enable: true
+#      number_of_slots: 256
+#      number_of_shards: 2048
+#      endorsement_lag: 2
+#      availability_threshold: 50
+#      slot_size: 1048576
+#      redundancy_factor: 16
+#      page_size: 4096
+#    sc_rollup_enable: true
 #    sc_rollup_origination_size: 6314
 #    sc_rollup_challenge_window_in_blocks: 40
-#    sc_rollup_max_available_messages: 1000000
+#    sc_rollup_stake_amount: "32000000"
+#    sc_rollup_commitment_period_in_blocks: 20
+#    sc_rollup_max_lookahead_in_blocks: 30000
+#    sc_rollup_max_active_outbox_levels: 20160
+#    sc_rollup_max_outbox_messages_per_level: 100
+#    sc_rollup_max_number_of_cemented_commitments: 5
+#    sc_rollup_max_number_of_messages_per_commitment_period: 32765
+#    sc_rollup_number_of_sections_in_dissection: 32
+#    sc_rollup_timeout_period_in_blocks: 500
+#    zk_rollup_enable: true
+#    zk_rollup_origination_size: 4000
+#    zk_rollup_min_pending_to_process: 10
 #
 #   # Pass url pointing to additional contracts that you want injected at activation.
 #   # This data is typically too large to pass it directly inside helm chart.

--- a/docs/Prerequisites.md
+++ b/docs/Prerequisites.md
@@ -115,7 +115,7 @@ Or, if you prefer, you can build the image using:
 ./scripts/create_docker_image.sh
 ```
 
-This will create an image with a name like `tezos/tezos:v14.0`.
+This will create an image with a name like `tezos/tezos:v15.0`.
 Then you install it thus:
 ```shell
 docker image save <image> | ( eval $(minikube docker-env); docker image load )

--- a/docs/Private-Chain.md
+++ b/docs/Private-Chain.md
@@ -199,7 +199,7 @@ On each computer, run this command to check that the nodes have matching heads b
 ```shell
 kubectl get pod -n oxheadalpha -l appType=octez-node -o name |
 while read line;
-  do kubectl -n oxheadalpha exec $line -c octez-node -- /usr/local/bin/tezos-client rpc get /chains/main/blocks/head/hash;
+  do kubectl -n oxheadalpha exec $line -c octez-node -- /usr/local/bin/octez-client rpc get /chains/main/blocks/head/hash;
 done
 ```
 

--- a/mkchain/README.md
+++ b/mkchain/README.md
@@ -86,7 +86,7 @@ You can explicitly specify some values by:
 |                                  | --number-of-nodes        | Number of non-baking nodes in the cluster                      | 0                       |
 | bootstrap_peers                  | --bootstrap-peers        | Peer ips to connect to                                         | []                      |
 | expected_proof_of_work           | --expected-proof-of-work | Node identity generation difficulty                            | 0                       |
-| images.octez                     | --octez-docker-image     | Version of the Octez docker image to run                       | tezos/tezos:v14-release |
+| images.octez                     | --octez-docker-image     | Version of the Octez docker image to run                       | tezos/tezos:v15-release |
 |                                  | --use-docker (--no...)   | Use (or don't use) docker to generate keys rather than pytezos | autodetect              |
 | zerotier_config.zerotier_network | --zerotier-network       | Zerotier network id for external chain access                  |                         |
 | zerotier_config.zerotier_token   | --zerotier-token         | Zerotier token for external chain access                       |                         |

--- a/mkchain/tqchain/keys.py
+++ b/mkchain/tqchain/keys.py
@@ -57,9 +57,9 @@ def gen_key(image):
         image,
         "sh",
         "-c",
-        "'/usr/local/bin/tezos-client "
+        "'/usr/local/bin/octez-client "
         + "--protocol PsDELPH1Kxsx gen keys mykey && "
-        + "/usr/local/bin/tezos-client "
+        + "/usr/local/bin/octez-client "
         + "--protocol PsDELPH1Kxsx show address mykey -S'",
     ).split(b"\n")
 

--- a/mkchain/tqchain/mkchain.py
+++ b/mkchain/tqchain/mkchain.py
@@ -40,7 +40,7 @@ cli_args = {
     "should_generate_unsafe_deterministic_data": {
         "help": (
             "Should tezos-k8s generate deterministic account keys and genesis"
-            " block hash instead of mkchain using tezos-client to generate"
+            " block hash instead of mkchain using octez-client to generate"
             " random ones. This option is helpful for testing purposes."
         ),
         "action": "store_true",
@@ -70,7 +70,7 @@ cli_args = {
     },
     "octez_docker_image": {
         "help": "Version of the Octez docker image",
-        "default": "tezos/tezos:v14-release",
+        "default": "tezos/tezos:v15-release",
     },
     "use_docker": {
         "action": "store_true",
@@ -190,7 +190,7 @@ def main():
         },
         "protocols": [
             {
-                "command": "014-PtKathma",
+                "command": "PtLimaPt",
                 "vote": {"liquidity_baking_toggle_vote": "pass"},
             }
         ],
@@ -296,7 +296,7 @@ def main():
         parametersYaml = yaml.safe_load(yaml_file)
         activation = {
             "activation": {
-                "protocol_hash": "PtKathmankSpLLDALzWw7CGD2j2MtyveTwboEYokqUCP4a1LxMg",
+                "protocol_hash": "PtLimaPtLMwfNinJi9rCfDPWea8dFgTZ1MeJ9f1m2SRic6ayiwW",
                 "protocol_parameters": parametersYaml,
             },
         }

--- a/mkchain/tqchain/parameters.yaml
+++ b/mkchain/tqchain/parameters.yaml
@@ -6,7 +6,7 @@ cycles_per_voting_period: 1
 hard_gas_limit_per_operation: '1040000'
 hard_gas_limit_per_block: '5200000'
 proof_of_work_threshold: '-1'
-tokens_per_roll: '6000000000'
+minimal_stake: '6000000000'
 seed_nonce_revelation_tip: '125000'
 baking_reward_fixed_portion: '10000000'
 baking_reward_bonus_per_slot: '4286'
@@ -18,7 +18,6 @@ quorum_max: 7000
 quorum_min: 2000
 min_proposal_quorum: 500
 liquidity_baking_subsidy: '2500000'
-liquidity_baking_sunset_level: 10000000
 liquidity_baking_toggle_ema_threshold: 100000
 max_operations_time_to_live: 120
 minimal_block_delay: "5"
@@ -60,12 +59,21 @@ dal_parametric:
   number_of_shards: 2048
   endorsement_lag: 2
   availability_threshold: 50
+  slot_size: 1048576
+  redundancy_factor: 16
+  page_size: 4096
 sc_rollup_enable: true
 sc_rollup_origination_size: 6314
 sc_rollup_challenge_window_in_blocks: 40
-sc_rollup_max_available_messages: 1000000
 sc_rollup_stake_amount: "32000000"
 sc_rollup_commitment_period_in_blocks: 20
 sc_rollup_max_lookahead_in_blocks: 30000
 sc_rollup_max_active_outbox_levels: 20160
 sc_rollup_max_outbox_messages_per_level: 100
+sc_rollup_max_number_of_cemented_commitments: 5
+sc_rollup_max_number_of_messages_per_commitment_period: 32765
+sc_rollup_number_of_sections_in_dissection: 32
+sc_rollup_timeout_period_in_blocks: 500
+zk_rollup_enable: true
+zk_rollup_origination_size: 4000
+zk_rollup_min_pending_to_process: 10

--- a/rpc-auth/README.md
+++ b/rpc-auth/README.md
@@ -49,10 +49,10 @@ helm upgrade $CHAIN_NAME oxheadalpha/tezos-chain \
 
    - Run
      ```shell
-     kubectl exec -it -n oxheadalpha statefulset/tezos-baking-node -c tezos-node -- tezos-client rpc get /chains/main/chain_id
+     kubectl exec -it -n oxheadalpha statefulset/tezos-baking-node -c octez-node -- octez-client rpc get /chains/main/chain_id
      ```
    - Use a tool like [Lens](https://k8slens.dev/) to view the logs of the Tezos node. (As well as the rest of your k8s infrastructure)
-   - Manually run the logs command `kubectl logs -n oxheadalpha statefulset/tezos-baking-node -c tezos-node`. The top of the logs should look similar to:
+   - Manually run the logs command `kubectl logs -n oxheadalpha statefulset/tezos-baking-node -c octez-node`. The top of the logs should look similar to:
      ```
      Dec 21 19:42:08 - node.main: starting the Tezos node (chain = my-chain)
      Dec 21 19:42:08 - node.main: disabled local peer discovery
@@ -66,7 +66,7 @@ helm upgrade $CHAIN_NAME oxheadalpha/tezos-chain \
      ```
      The chain id is printed on the last line: `NetXitypWekag8Z`.
 
-2. The user needs to have a Tezos secret key either generated or imported by `tezos-client`. The user's secret key is used to sign some data for the server to then verify.
+2. The user needs to have a Tezos secret key either generated or imported by `octez-client`. The user's secret key is used to sign some data for the server to then verify.
 
 3. The user runs: `rpc-auth/client/init.sh --cluster-address $CLUSTER_IP --tz-alias $TZ_ALIAS --chain-id $CHAIN_ID`
 
@@ -78,5 +78,5 @@ helm upgrade $CHAIN_NAME oxheadalpha/tezos-chain \
    - `curl http://192.168.64.51/tezos-node-rpc/ffff3eb3d7dd4f6bbff3f2fd096722ae/chains/main/chain_id`
    - As of docker image `tezos/tezos:v9-release`:
      ```shell
-     tezos-client --endpoint http://192.168.64.51/tezos-node-rpc/ffff3eb3d7dd4f6bbff3f2fd096722ae/ rpc get chains/main/chain_id
+     octez-client --endpoint http://192.168.64.51/tezos-node-rpc/ffff3eb3d7dd4f6bbff3f2fd096722ae/ rpc get chains/main/chain_id
      ```

--- a/snapshotEngine/mainJob.yaml
+++ b/snapshotEngine/mainJob.yaml
@@ -32,13 +32,13 @@ spec:
               NETWORK="${NETWORK_OVERRIDE:-${NAMESPACE%%-*}}"
 
               # Set up config for headless RPC using new restored storage
-              tezos-node config init \
+              octez-node config init \
               --config-file /home/tezos/.tezos-node/config.json \
               --network "${NETWORK}" \
               --data-dir /var/tezos/node/data
 
               # Run headless tezos node to validate storage on restored volume
-              tezos-node run --connections 0 --config-file /home/tezos/.tezos-node/config.json --rpc-addr=127.0.0.1:8732 &
+              octez-node run --connections 0 --config-file /home/tezos/.tezos-node/config.json --rpc-addr=127.0.0.1:8732 &
 
               # Limit validation to restoredStorageInitTime. If this takes longer then there is a tezos error
               # and this job is tossed.
@@ -119,8 +119,8 @@ spec:
               # Get BLOCK_TIMESTAMP from RPC
               wget -qO-  http://localhost:8732/chains/main/blocks/head/header | sed -E 's/.*"timestamp":"?([^,"]*)"?.*/\1/' > /"${HISTORY_MODE}"-snapshot-cache-volume/BLOCK_TIMESTAMP
 
-              # Get Tezos Version from tezos-node command
-              /usr/local/bin/tezos-node --version > /"${HISTORY_MODE}"-snapshot-cache-volume/TEZOS_VERSION
+              # Get Tezos Version from octez-node command
+              /usr/local/bin/octez-node --version > /"${HISTORY_MODE}"-snapshot-cache-volume/TEZOS_VERSION
 
               # Print variables for debug
               printf "%s BLOCK_HASH is...$(cat /"${HISTORY_MODE}"-snapshot-cache-volume/BLOCK_HASH))\n" "$(date "+%Y-%m-%d %H:%M:%S" "$@")"
@@ -162,13 +162,13 @@ spec:
               BLOCK_HASH=$(cat /"${HISTORY_MODE}"-snapshot-cache-volume/BLOCK_HASH)
               ROLLING_SNAPSHOT_NAME="${NAMESPACE%%-*}"-"${BLOCK_HEIGHT}"
 
-              tezos-node config init \
+              octez-node config init \
               --config-file /home/tezos/.tezos-node/config.json \
               --network "${NETWORK}" \
               --data-dir /var/tezos/node/data
 
               if [ "${HISTORY_MODE}" = rolling ]; then
-                tezos-node snapshot export \
+                octez-node snapshot export \
                 --block "${BLOCK_HASH}" \
                 --config-file /home/tezos/.tezos-node/config.json \
                 --rolling \
@@ -178,7 +178,7 @@ spec:
 
                 touch /rolling-tarball-restore/snapshot-import-in-progress
 
-                tezos-node snapshot import \
+                octez-node snapshot import \
                 /"${HISTORY_MODE}"-snapshot-cache-volume/"${ROLLING_SNAPSHOT_NAME}".rolling \
                 --in-memory \
                 --block "${BLOCK_HASH}" \

--- a/snapshotEngine/snapshot-maker.sh
+++ b/snapshotEngine/snapshot-maker.sh
@@ -5,7 +5,7 @@ cd /
 ZIP_AND_UPLOAD_JOB_NAME=zip-and-upload-"${HISTORY_MODE}"
 
 # Pause if nodes are not ready
-while [ "$(kubectl get pods -n "${NAMESPACE}" -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}' -l appType=tezos-node -l node_class_history_mode="${HISTORY_MODE}")" = "False" ]; do
+while [ "$(kubectl get pods -n "${NAMESPACE}" -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}' -l appType=octez-node -l node_class_history_mode="${HISTORY_MODE}")" = "False" ]; do
     printf "%s Tezos node is not ready for snapshot.  Check node pod logs.  \n" "$(date "+%Y-%m-%d %H:%M:%S" "$@")"
     sleep 30
 done

--- a/test/charts/mainnet.expect.yaml
+++ b/test/charts/mainnet.expect.yaml
@@ -77,7 +77,7 @@ spec:
     - port: 8732
       name: rpc
   selector:
-    appType: tezos-node
+    appType: octez-node
   type: NodePort
 ---
 # Source: tezos-chain/templates/static.yaml
@@ -86,7 +86,7 @@ kind: Service
 metadata:
   name: rolling-node
   labels:
-    appType: tezos-node
+    appType: octez-node
 spec:
   ports:
     - port: 9732
@@ -114,12 +114,12 @@ spec:
   template:
     metadata:
       labels:
-        appType: tezos-node
+        appType: octez-node
         node_class: rolling-node
     spec:
       containers:        
         - name: octez-node
-          image: "tezos/tezos:v14-release"
+          image: "tezos/tezos:v15-release"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -130,15 +130,15 @@ spec:
               
               set
               
-              # ensure we can run tezos-client commands without specifying client dir
+              # ensure we can run octez-client commands without specifying client dir
               ln -s /var/tezos/client /home/tezos/.tezos-client
               #
               # Not every error is fatal on start.  In particular, with zerotier,
-              # the listen-addr may not yet be bound causing tezos-node to fail.
+              # the listen-addr may not yet be bound causing octez-node to fail.
               # So, we try a few times with increasing delays:
               
               for d in 1 1 5 10 20 60 120; do
-              	/usr/local/bin/tezos-node run				\
+              	/usr/local/bin/octez-node run				\
               			--bootstrap-threshold 0			\
               			--config-file /etc/tezos/config.json
               	sleep $d
@@ -199,7 +199,7 @@ spec:
               name: var-volume        
       initContainers:        
         - name: config-init
-          image: "tezos/tezos:v14-release"
+          image: "tezos/tezos:v15-release"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -212,7 +212,7 @@ spec:
               #
               # This is my comment.
               
-              /usr/local/bin/tezos-node config init		\
+              /usr/local/bin/octez-node config init		\
                   --config-file /etc/tezos/data/config.json	\
                   --data-dir /etc/tezos/data			\
                   --network $CHAIN_NAME
@@ -303,7 +303,7 @@ spec:
             - mountPath: /var/tezos
               name: var-volume        
         - name: snapshot-importer
-          image: "tezos/tezos:v14-release"
+          image: "tezos/tezos:v15-release"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -316,7 +316,7 @@ spec:
               data_dir="/var/tezos"
               node_dir="$data_dir/node"
               node_data_dir="$node_dir/data"
-              node="$bin_dir/tezos-node"
+              node="$bin_dir/octez-node"
               snapshot_file=${node_dir}/chain.snapshot
               
               if [ -d ${node_data_dir}/context ]; then
@@ -358,7 +358,7 @@ spec:
             - mountPath: /var/tezos
               name: var-volume                
         - name: upgrade-storage
-          image: "tezos/tezos:v14-release"
+          image: "tezos/tezos:v15-release"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -372,7 +372,7 @@ spec:
                 printf "No context in data dir found, probably initial start, doing nothing."
                 exit 0
               fi
-              tezos-node upgrade storage --data-dir /var/tezos/node/data
+              octez-node upgrade storage --data-dir /var/tezos/node/data
               
           envFrom:
           env:

--- a/test/charts/mainnet2.expect.yaml
+++ b/test/charts/mainnet2.expect.yaml
@@ -68,7 +68,7 @@ data:
           }
         },
         "images": {
-          "octez": "tezos/tezos:v14-release"
+          "octez": "tezos/tezos:v15-release"
         },
         "instances": [
           {
@@ -116,7 +116,7 @@ spec:
     - port: 8732
       name: rpc
   selector:
-    appType: tezos-node
+    appType: octez-node
   type: NodePort
 ---
 # Source: tezos-chain/templates/static.yaml
@@ -125,7 +125,7 @@ kind: Service
 metadata:
   name: city-block
   labels:
-    appType: tezos-node
+    appType: octez-node
 spec:
   ports:
     - port: 9732
@@ -143,7 +143,7 @@ kind: Service
 metadata:
   name: country-town
   labels:
-    appType: tezos-node
+    appType: octez-node
 spec:
   ports:
     - port: 9732
@@ -171,12 +171,12 @@ spec:
   template:
     metadata:
       labels:
-        appType: tezos-node
+        appType: octez-node
         node_class: city-block
     spec:
       containers:        
         - name: octez-node
-          image: "tezos/tezos:v14-release"
+          image: "tezos/tezos:v15-release"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -187,15 +187,15 @@ spec:
               
               set
               
-              # ensure we can run tezos-client commands without specifying client dir
+              # ensure we can run octez-client commands without specifying client dir
               ln -s /var/tezos/client /home/tezos/.tezos-client
               #
               # Not every error is fatal on start.  In particular, with zerotier,
-              # the listen-addr may not yet be bound causing tezos-node to fail.
+              # the listen-addr may not yet be bound causing octez-node to fail.
               # So, we try a few times with increasing delays:
               
               for d in 1 1 5 10 20 60 120; do
-              	/usr/local/bin/tezos-node run				\
+              	/usr/local/bin/octez-node run				\
               			--bootstrap-threshold 0			\
               			--config-file /etc/tezos/config.json
               	sleep $d
@@ -292,7 +292,7 @@ spec:
               name: var-volume        
       initContainers:        
         - name: config-init
-          image: "tezos/tezos:v14-release"
+          image: "tezos/tezos:v15-release"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -305,7 +305,7 @@ spec:
               #
               # This is my comment.
               
-              /usr/local/bin/tezos-node config init		\
+              /usr/local/bin/octez-node config init		\
                   --config-file /etc/tezos/data/config.json	\
                   --data-dir /etc/tezos/data			\
                   --network $CHAIN_NAME
@@ -402,7 +402,7 @@ spec:
             - mountPath: /var/tezos
               name: var-volume        
         - name: snapshot-importer
-          image: "tezos/tezos:v14-release"
+          image: "tezos/tezos:v15-release"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -415,7 +415,7 @@ spec:
               data_dir="/var/tezos"
               node_dir="$data_dir/node"
               node_data_dir="$node_dir/data"
-              node="$bin_dir/tezos-node"
+              node="$bin_dir/octez-node"
               snapshot_file=${node_dir}/chain.snapshot
               
               if [ -d ${node_data_dir}/context ]; then
@@ -459,7 +459,7 @@ spec:
             - mountPath: /var/tezos
               name: var-volume                
         - name: upgrade-storage
-          image: "tezos/tezos:v14-release"
+          image: "tezos/tezos:v15-release"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -473,7 +473,7 @@ spec:
                 printf "No context in data dir found, probably initial start, doing nothing."
                 exit 0
               fi
-              tezos-node upgrade storage --data-dir /var/tezos/node/data
+              octez-node upgrade storage --data-dir /var/tezos/node/data
               
           envFrom:
           env:
@@ -524,12 +524,12 @@ spec:
   template:
     metadata:
       labels:
-        appType: tezos-node
+        appType: octez-node
         node_class: country-town
     spec:
       containers:        
         - name: octez-node
-          image: "tezos/tezos:v14-release"
+          image: "tezos/tezos:v15-release"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -540,15 +540,15 @@ spec:
               
               set
               
-              # ensure we can run tezos-client commands without specifying client dir
+              # ensure we can run octez-client commands without specifying client dir
               ln -s /var/tezos/client /home/tezos/.tezos-client
               #
               # Not every error is fatal on start.  In particular, with zerotier,
-              # the listen-addr may not yet be bound causing tezos-node to fail.
+              # the listen-addr may not yet be bound causing octez-node to fail.
               # So, we try a few times with increasing delays:
               
               for d in 1 1 5 10 20 60 120; do
-              	/usr/local/bin/tezos-node run				\
+              	/usr/local/bin/octez-node run				\
               			--bootstrap-threshold 0			\
               			--config-file /etc/tezos/config.json
               	sleep $d
@@ -645,7 +645,7 @@ spec:
               name: var-volume        
       initContainers:        
         - name: config-init
-          image: "tezos/tezos:v14-release"
+          image: "tezos/tezos:v15-release"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -658,7 +658,7 @@ spec:
               #
               # This is my comment.
               
-              /usr/local/bin/tezos-node config init		\
+              /usr/local/bin/octez-node config init		\
                   --config-file /etc/tezos/data/config.json	\
                   --data-dir /etc/tezos/data			\
                   --network $CHAIN_NAME
@@ -755,7 +755,7 @@ spec:
             - mountPath: /var/tezos
               name: var-volume        
         - name: snapshot-importer
-          image: "tezos/tezos:v14-release"
+          image: "tezos/tezos:v15-release"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -768,7 +768,7 @@ spec:
               data_dir="/var/tezos"
               node_dir="$data_dir/node"
               node_data_dir="$node_dir/data"
-              node="$bin_dir/tezos-node"
+              node="$bin_dir/octez-node"
               snapshot_file=${node_dir}/chain.snapshot
               
               if [ -d ${node_data_dir}/context ]; then
@@ -812,7 +812,7 @@ spec:
             - mountPath: /var/tezos
               name: var-volume                
         - name: upgrade-storage
-          image: "tezos/tezos:v14-release"
+          image: "tezos/tezos:v15-release"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -826,7 +826,7 @@ spec:
                 printf "No context in data dir found, probably initial start, doing nothing."
                 exit 0
               fi
-              tezos-node upgrade storage --data-dir /var/tezos/node/data
+              octez-node upgrade storage --data-dir /var/tezos/node/data
               
           envFrom:
           env:

--- a/test/charts/mainnet2.in.yaml
+++ b/test/charts/mainnet2.in.yaml
@@ -14,7 +14,7 @@ nodes:
       snapshot-downloader:
         key: specific-container
     images:
-      octez: tezos/tezos:v14-release
+      octez: tezos/tezos:v15-release
     runs: [ octez_node, logger, metrics ]
     instances:
     - config:

--- a/test/charts/private-chain.expect.yaml
+++ b/test/charts/private-chain.expect.yaml
@@ -110,18 +110,6 @@ data:
 
   NODES: |
     {
-      "af": {
-        "instances": [
-          {}
-        ],
-        "runs": [
-          "tezedge_node",
-          "baker",
-          "logger",
-          "metrics"
-        ],
-        "storage_size": "15Gi"
-      },
       "as": {
         "instances": [
           {}
@@ -132,7 +120,7 @@ data:
       },
       "eu": {
         "images": {
-          "octez": "tezos/tezos:v14-release"
+          "octez": "tezos/tezos:v15-release"
         },
         "instances": [
           {
@@ -161,7 +149,6 @@ data:
         "runs": [
           "octez_node",
           "baker",
-          "endorser",
           "logger",
           "metrics"
         ],
@@ -174,8 +161,7 @@ data:
         ],
         "runs": [
           "octez_node",
-          "baker",
-          "endorser"
+          "baker"
         ],
         "storage_size": "15Gi"
       }
@@ -228,26 +214,8 @@ spec:
     - port: 8732
       name: rpc
   selector:
-    appType: tezos-node
+    appType: octez-node
   type: NodePort
----
-# Source: tezos-chain/templates/static.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: af
-  labels:
-    appType: tezos-node
-spec:
-  ports:
-    - port: 9732
-      name: p2p
-    - port: 9932
-      name: metrics
-  publishNotReadyAddresses: true
-  clusterIP: None
-  selector:
-    node_class: af
 ---
 # Source: tezos-chain/templates/static.yaml
 apiVersion: v1
@@ -255,7 +223,7 @@ kind: Service
 metadata:
   name: as
   labels:
-    appType: tezos-node
+    appType: octez-node
 spec:
   ports:
     - port: 9732
@@ -273,7 +241,7 @@ kind: Service
 metadata:
   name: eu
   labels:
-    appType: tezos-node
+    appType: octez-node
 spec:
   ports:
     - port: 9732
@@ -291,7 +259,7 @@ kind: Service
 metadata:
   name: us
   labels:
-    appType: tezos-node
+    appType: octez-node
 spec:
   ports:
     - port: 9732
@@ -302,295 +270,6 @@ spec:
   clusterIP: None
   selector:
     node_class: us
----
-# Source: tezos-chain/templates/nodes.yaml
-apiVersion: apps/v1
-kind: StatefulSet
-metadata:
-  name: af
-  namespace: testing
-spec:
-  podManagementPolicy: Parallel
-  replicas: 1
-  serviceName: af
-  selector:
-    matchLabels:
-      node_class: af
-  template:
-    metadata:
-      labels:
-        appType: tezos-node
-        node_class: af
-        baking_node: "true"
-    spec:
-      containers:        
-        - name: octez-node
-          image: "tezos/tezos:v14-release"
-          imagePullPolicy: IfNotPresent
-          command:
-            - /bin/sh
-          args:
-            - "-c"
-            - |
-              set -x
-              
-              set
-              
-              # ensure we can run tezos-client commands without specifying client dir
-              ln -s /var/tezos/client /home/tezos/.tezos-client
-              #
-              # Not every error is fatal on start.  In particular, with zerotier,
-              # the listen-addr may not yet be bound causing tezos-node to fail.
-              # So, we try a few times with increasing delays:
-              
-              for d in 1 1 5 10 20 60 120; do
-              	/usr/local/bin/tezos-node run				\
-              			--bootstrap-threshold 0			\
-              			--config-file /etc/tezos/config.json
-              	sleep $d
-              done
-              
-              #
-              # Keep the container alive for troubleshooting on failures:
-              
-              sleep 3600
-              
-          envFrom:
-          env:
-            - name: DAEMON
-              value: octez-node
-          volumeMounts:
-            - mountPath: /etc/tezos
-              name: config-volume
-            - mountPath: /var/tezos
-              name: var-volume
-          ports:
-            - containerPort: 8732
-              name: tezos-rpc
-            - containerPort: 9732
-              name: tezos-net
-            - containerPort: 9932
-              name: metrics
-          readinessProbe:
-            httpGet:
-              path: /is_synced
-              port: 31732                
-        - name: baker-013-ptjakart
-          image: "tezos/tezos:v14-release"
-          imagePullPolicy: IfNotPresent
-          command:
-            - /bin/sh
-          args:
-            - "-c"
-            - |
-              set -ex
-              
-              TEZ_VAR=/var/tezos
-              TEZ_BIN=/usr/local/bin
-              CLIENT_DIR="$TEZ_VAR/client"
-              NODE_DIR="$TEZ_VAR/node"
-              NODE_DATA_DIR="$TEZ_VAR/node/data"
-              BAKER_EXTRA_ARGS_FROM_ENV=${BAKER_EXTRA_ARGS}
-              
-              proto_command="013-PtJakart"
-              
-              per_block_vote_file=/etc/tezos/per-block-votes/${proto_command}-per-block-votes.json
-              if [ $(cat $per_block_vote_file) == "null" ]; then
-                cat << EOF
-              You must pass per-block-votes (such as liquidity_baking_toggle_vote) in values.yaml, for example:
-              protocols:
-              - command: ${proto_command}
-                vote:
-                  liquidity_baking_toggle_vote: "on"
-              EOF
-                exit 1
-              fi
-              extra_args="--votefile ${per_block_vote_file}"
-              
-              tezos_version=$(tezos-client --version | sed -e 's/ //g')
-              if [[ "$tezos_version" == *"13.0"* ]]; then
-                # version 13 of octez mandates CLI flag as well as vote file
-                extra_args="$extra_args --liquidity-baking-toggle-vote on"
-              fi
-              
-              my_baker_account="$(cat /etc/tezos/baker-account )"
-              
-              CLIENT="$TEZ_BIN/tezos-client -d $CLIENT_DIR"
-              CMD="$TEZ_BIN/tezos-baker-$proto_command -d $CLIENT_DIR"
-              
-              # ensure we can run tezos-client commands without specifying client dir
-              ln -s /var/tezos/client /home/tezos/.tezos-client
-              
-              while ! $CLIENT rpc get chains/main/blocks/head; do
-                  sleep 5
-              done
-              
-              exec $CMD run with local node $NODE_DATA_DIR ${extra_args} ${BAKER_EXTRA_ARGS_FROM_ENV} ${my_baker_account}
-              
-          envFrom:
-          env:
-            - name: DAEMON
-              value: baker
-          volumeMounts:
-            - mountPath: /etc/tezos
-              name: config-volume
-            - mountPath: /var/tezos
-              name: var-volume
-            - mountPath: /etc/tezos/per-block-votes
-              name: per-block-votes        
-        - name: logger
-          image: "ghcr.io/oxheadalpha/tezos-k8s-utils:master"
-          imagePullPolicy: IfNotPresent
-          args:
-            - logger
-          envFrom:
-            - configMapRef:
-                name: tezos-config
-          env:    
-            - name: MY_POD_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIP
-            - name: MY_POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: MY_POD_TYPE
-              value: node
-            - name: MY_NODE_CLASS
-              value: af
-            - name: DAEMON
-              value: logger
-          volumeMounts:
-            - mountPath: /etc/tezos
-              name: config-volume
-            - mountPath: /var/tezos
-              name: var-volume                
-        - name: sidecar
-          image: "ghcr.io/oxheadalpha/tezos-k8s-utils:master"
-          imagePullPolicy: IfNotPresent
-          args:
-            - sidecar
-          envFrom:
-            - configMapRef:
-                name: tezos-config
-          env:    
-            - name: MY_POD_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIP
-            - name: MY_POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: MY_POD_TYPE
-              value: node
-            - name: MY_NODE_CLASS
-              value: af
-            - name: DAEMON
-              value: sidecar
-          volumeMounts:
-            - mountPath: /etc/tezos
-              name: config-volume
-            - mountPath: /var/tezos
-              name: var-volume        
-      initContainers:                        
-        - name: config-generator
-          image: "ghcr.io/oxheadalpha/tezos-k8s-utils:master"
-          imagePullPolicy: IfNotPresent
-          args:
-            - config-generator
-          envFrom:
-            - configMapRef:
-                name: tezos-config
-          env:    
-            - name: MY_POD_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIP
-            - name: MY_POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: MY_POD_TYPE
-              value: node
-            - name: MY_NODE_CLASS
-              value: af
-            - name: DAEMON
-              value: config-generator
-          volumeMounts:
-            - mountPath: /etc/tezos
-              name: config-volume
-            - mountPath: /var/tezos
-              name: var-volume
-            - mountPath: /etc/secret-volume
-              name: tezos-accounts                        
-        - name: wait-for-dns
-          image: "ghcr.io/oxheadalpha/tezos-k8s-utils:master"
-          imagePullPolicy: IfNotPresent
-          args:
-            - wait-for-dns
-          envFrom:
-            - configMapRef:
-                name: tezos-config
-          env:
-            - name: DAEMON
-              value: wait-for-dns
-          volumeMounts:
-            - mountPath: /etc/tezos
-              name: config-volume
-            - mountPath: /var/tezos
-              name: var-volume        
-        - name: upgrade-storage
-          image: "tezos/tezos:v14-release"
-          imagePullPolicy: IfNotPresent
-          command:
-            - /bin/sh
-          args:
-            - "-c"
-            - |
-              set -ex
-              
-              if [ ! -e /var/tezos/node/data/context ]
-              then
-                printf "No context in data dir found, probably initial start, doing nothing."
-                exit 0
-              fi
-              tezos-node upgrade storage --data-dir /var/tezos/node/data
-              
-          envFrom:
-          env:
-            - name: DAEMON
-              value: upgrade-storage
-          volumeMounts:
-            - mountPath: /etc/tezos
-              name: config-volume
-            - mountPath: /var/tezos
-              name: var-volume
-      securityContext:
-        fsGroup: 1000      
-      volumes:
-        - hostPath:
-            path: /dev/net/tun
-          name: dev-net-tun
-        - emptyDir: {}
-          name: config-volume
-        - name: tezos-accounts
-          secret:
-            secretName: tezos-secret
-        - name: per-block-votes
-          configMap:
-            name: per-block-votes
-  volumeClaimTemplates:
-    - metadata:
-        name: var-volume
-        namespace: testing
-      spec:
-        accessModes:
-          - ReadWriteOnce
-        resources:
-          requests:
-            storage: 15Gi
 ---
 # Source: tezos-chain/templates/nodes.yaml
 apiVersion: apps/v1
@@ -608,12 +287,12 @@ spec:
   template:
     metadata:
       labels:
-        appType: tezos-node
+        appType: octez-node
         node_class: as
     spec:
       containers:        
         - name: octez-node
-          image: "tezos/tezos:v14-release"
+          image: "tezos/tezos:v15-release"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -624,15 +303,15 @@ spec:
               
               set
               
-              # ensure we can run tezos-client commands without specifying client dir
+              # ensure we can run octez-client commands without specifying client dir
               ln -s /var/tezos/client /home/tezos/.tezos-client
               #
               # Not every error is fatal on start.  In particular, with zerotier,
-              # the listen-addr may not yet be bound causing tezos-node to fail.
+              # the listen-addr may not yet be bound causing octez-node to fail.
               # So, we try a few times with increasing delays:
               
               for d in 1 1 5 10 20 60 120; do
-              	/usr/local/bin/tezos-node run				\
+              	/usr/local/bin/octez-node run				\
               			--bootstrap-threshold 0			\
               			--config-file /etc/tezos/config.json
               	sleep $d
@@ -739,7 +418,7 @@ spec:
             - mountPath: /var/tezos
               name: var-volume        
         - name: upgrade-storage
-          image: "tezos/tezos:v14-release"
+          image: "tezos/tezos:v15-release"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -753,7 +432,7 @@ spec:
                 printf "No context in data dir found, probably initial start, doing nothing."
                 exit 0
               fi
-              tezos-node upgrade storage --data-dir /var/tezos/node/data
+              octez-node upgrade storage --data-dir /var/tezos/node/data
               
           envFrom:
           env:
@@ -805,14 +484,14 @@ spec:
   template:
     metadata:
       labels:
-        appType: tezos-node
+        appType: octez-node
         node_class: eu
         baking_node: "true"
         rpc_node: "true"
     spec:
       containers:        
         - name: octez-node
-          image: "tezos/tezos:v14-release"
+          image: "tezos/tezos:v15-release"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -823,15 +502,15 @@ spec:
               
               set
               
-              # ensure we can run tezos-client commands without specifying client dir
+              # ensure we can run octez-client commands without specifying client dir
               ln -s /var/tezos/client /home/tezos/.tezos-client
               #
               # Not every error is fatal on start.  In particular, with zerotier,
-              # the listen-addr may not yet be bound causing tezos-node to fail.
+              # the listen-addr may not yet be bound causing octez-node to fail.
               # So, we try a few times with increasing delays:
               
               for d in 1 1 5 10 20 60 120; do
-              	/usr/local/bin/tezos-node run				\
+              	/usr/local/bin/octez-node run				\
               			--bootstrap-threshold 0			\
               			--config-file /etc/tezos/config.json
               	sleep $d
@@ -863,7 +542,7 @@ spec:
               path: /is_synced
               port: 31732                
         - name: baker-013-ptjakart
-          image: "tezos/tezos:v14-release"
+          image: "tezos/tezos:v15-release"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -894,7 +573,7 @@ spec:
               fi
               extra_args="--votefile ${per_block_vote_file}"
               
-              tezos_version=$(tezos-client --version | sed -e 's/ //g')
+              tezos_version=$(octez-client --version | sed -e 's/ //g')
               if [[ "$tezos_version" == *"13.0"* ]]; then
                 # version 13 of octez mandates CLI flag as well as vote file
                 extra_args="$extra_args --liquidity-baking-toggle-vote on"
@@ -902,10 +581,10 @@ spec:
               
               my_baker_account="$(cat /etc/tezos/baker-account )"
               
-              CLIENT="$TEZ_BIN/tezos-client -d $CLIENT_DIR"
+              CLIENT="$TEZ_BIN/octez-client -d $CLIENT_DIR"
               CMD="$TEZ_BIN/tezos-baker-$proto_command -d $CLIENT_DIR"
               
-              # ensure we can run tezos-client commands without specifying client dir
+              # ensure we can run octez-client commands without specifying client dir
               ln -s /var/tezos/client /home/tezos/.tezos-client
               
               while ! $CLIENT rpc get chains/main/blocks/head; do
@@ -1029,7 +708,7 @@ spec:
             - mountPath: /var/tezos
               name: var-volume        
         - name: upgrade-storage
-          image: "tezos/tezos:v14-release"
+          image: "tezos/tezos:v15-release"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -1043,7 +722,7 @@ spec:
                 printf "No context in data dir found, probably initial start, doing nothing."
                 exit 0
               fi
-              tezos-node upgrade storage --data-dir /var/tezos/node/data
+              octez-node upgrade storage --data-dir /var/tezos/node/data
               
           envFrom:
           env:
@@ -1095,13 +774,13 @@ spec:
   template:
     metadata:
       labels:
-        appType: tezos-node
+        appType: octez-node
         node_class: us
         baking_node: "true"
     spec:
       containers:        
         - name: octez-node
-          image: "tezos/tezos:v14-release"
+          image: "tezos/tezos:v15-release"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -1112,15 +791,15 @@ spec:
               
               set
               
-              # ensure we can run tezos-client commands without specifying client dir
+              # ensure we can run octez-client commands without specifying client dir
               ln -s /var/tezos/client /home/tezos/.tezos-client
               #
               # Not every error is fatal on start.  In particular, with zerotier,
-              # the listen-addr may not yet be bound causing tezos-node to fail.
+              # the listen-addr may not yet be bound causing octez-node to fail.
               # So, we try a few times with increasing delays:
               
               for d in 1 1 5 10 20 60 120; do
-              	/usr/local/bin/tezos-node run				\
+              	/usr/local/bin/octez-node run				\
               			--bootstrap-threshold 0			\
               			--config-file /etc/tezos/config.json
               	sleep $d
@@ -1152,7 +831,7 @@ spec:
               path: /is_synced
               port: 31732                
         - name: baker-013-ptjakart
-          image: "tezos/tezos:v14-release"
+          image: "tezos/tezos:v15-release"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -1183,7 +862,7 @@ spec:
               fi
               extra_args="--votefile ${per_block_vote_file}"
               
-              tezos_version=$(tezos-client --version | sed -e 's/ //g')
+              tezos_version=$(octez-client --version | sed -e 's/ //g')
               if [[ "$tezos_version" == *"13.0"* ]]; then
                 # version 13 of octez mandates CLI flag as well as vote file
                 extra_args="$extra_args --liquidity-baking-toggle-vote on"
@@ -1191,10 +870,10 @@ spec:
               
               my_baker_account="$(cat /etc/tezos/baker-account )"
               
-              CLIENT="$TEZ_BIN/tezos-client -d $CLIENT_DIR"
+              CLIENT="$TEZ_BIN/octez-client -d $CLIENT_DIR"
               CMD="$TEZ_BIN/tezos-baker-$proto_command -d $CLIENT_DIR"
               
-              # ensure we can run tezos-client commands without specifying client dir
+              # ensure we can run octez-client commands without specifying client dir
               ln -s /var/tezos/client /home/tezos/.tezos-client
               
               while ! $CLIENT rpc get chains/main/blocks/head; do
@@ -1290,7 +969,7 @@ spec:
             - mountPath: /var/tezos
               name: var-volume        
         - name: upgrade-storage
-          image: "tezos/tezos:v14-release"
+          image: "tezos/tezos:v15-release"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -1304,7 +983,7 @@ spec:
                 printf "No context in data dir found, probably initial start, doing nothing."
                 exit 0
               fi
-              tezos-node upgrade storage --data-dir /var/tezos/node/data
+              octez-node upgrade storage --data-dir /var/tezos/node/data
               
           envFrom:
           env:
@@ -1360,7 +1039,7 @@ spec:
     spec:
       containers:
       - name: tezos-signer
-        image: "tezos/tezos:v14-release"
+        image: "tezos/tezos:v15-release"
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 6732
@@ -1431,14 +1110,14 @@ spec:
     spec:
       containers:        
         - name: chain-initiator
-          image: "tezos/tezos:v14-release"
+          image: "tezos/tezos:v15-release"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
           args:
             - "-c"
             - |
-              CLIENT="/usr/local/bin/tezos-client --endpoint http://tezos-node-rpc:8732"
+              CLIENT="/usr/local/bin/octez-client --endpoint http://tezos-node-rpc:8732"
               
               until $CLIENT rpc get /chains/main/blocks/head/header | grep '"level":'; do
                   sleep 2

--- a/test/charts/private-chain.in.yaml
+++ b/test/charts/private-chain.in.yaml
@@ -3,7 +3,7 @@
 #
 # Please note that we are trying to exercise as many features as
 # we can in a single chart.  In nodes:, e.g., we are ensuring that:
-# we are using both octez and tezedge; each runs list is different;
+# each runs list is different;
 # that we have some regular nodes; we use the config sections;
 # multiple baking accounts; etc.
 
@@ -76,7 +76,7 @@ full_snapshot_url: null
 rolling_snapshot_url: null
 archive_tarball_url: null
 images:
-  octez: 'tezos/tezos:v14-release'
+  octez: 'tezos/tezos:v15-release'
 is_invitation: false
 node_config_network:
   activation_account_name: tezos-baking-node-0
@@ -88,7 +88,7 @@ node_config_network:
 nodes:
   eu:
     images:
-      octez: tezos/tezos:v14-release
+      octez: tezos/tezos:v15-release
     labels:
       rpc_node: "true"
     instances:
@@ -98,18 +98,13 @@ nodes:
       is_bootstrap_node: true
     - is_bootstrap_node: true
     - {}
-    runs: [octez_node, baker, endorser, logger, metrics]
+    runs: [octez_node, baker, logger, metrics]
     storage_size: 15Gi
   us:
     instances:
     - {}
     - {}
-    runs: [octez_node, baker, endorser]
-    storage_size: 15Gi
-  af:
-    instances:
-    - {}
-    runs: [tezedge_node, baker, logger, metrics]
+    runs: [octez_node, baker]
     storage_size: 15Gi
   as:
     runs: [octez_node]

--- a/utils/config-generator.py
+++ b/utils/config-generator.py
@@ -566,7 +566,7 @@ def create_node_config_json(
     node_config = recursive_update(node_config, computed_node_config)
 
     if THIS_IS_A_PUBLIC_NET:
-        # `tezos-node config --network ...` will have been run in config-init.sh
+        # `octez-node config --network ...` will have been run in config-init.sh
         #  producing a config.json. The value passed to the `--network` flag may
         #  have been the chain name or a url to the config.json of the chain.
         #  Either way, set the `network` field here as the `network` object of the

--- a/utils/sidecar.py
+++ b/utils/sidecar.py
@@ -16,7 +16,7 @@ AGE_LIMIT_IN_SECS = 600
 def sync_checker():
     '''
     Here we don't trust the /is_bootstrapped endpoint of
-    tezos-node. We have seen it return true when the node is
+    octez-node. We have seen it return true when the node is
     in a bad state (for example, some crashed threads)
     Instead, we query the head block and verify timestamp is
     not too old.

--- a/utils/wait-for-dns.sh
+++ b/utils/wait-for-dns.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-# When the tezos-node boots for the first time, if one of the bootstrap
-# nodes can't be contacted, then tezos-node will give up.
+# When the octez-node boots for the first time, if one of the bootstrap
+# nodes can't be contacted, then octez-node will give up.
 # So at first boot (when peers.json is empty) we wait for bootstrap node.
 # This is probably a bug in tezos core, though.
 


### PR DESCRIPTION
* default mkchain chain is a lima chain
* examples in values.yaml show lima activation
* move default version of octez to v15
* rename tezos-node and -client to octez-node and -client across the board
* update tests to remove some old tezedge validation

I did test mkchain with no parameters and it activates properly.