### PR TITLE
Add better tezos_version information to snapshot metadata

### DIFF
--- a/snapshotEngine/zip-and-upload.sh
+++ b/snapshotEngine/zip-and-upload.sh
@@ -6,6 +6,7 @@ BLOCK_TIMESTAMP=$(cat /"${HISTORY_MODE}"-snapshot-cache-volume/BLOCK_TIMESTAMP)
 TEZOS_VERSION=$(cat /"${HISTORY_MODE}"-snapshot-cache-volume/TEZOS_VERSION)
 NETWORK="${NAMESPACE%%-*}"
 export S3_BUCKET="${NAMESPACE%-*}.${SNAPSHOT_WEBSITE_DOMAIN_NAME}"
+TEZOS_RPC_VERSION_INFO="$(wget -qO-  snapshot-"${HISTORY_MODE}"-node."${NAMESPACE}":8732/version)"
 
 cd /
 
@@ -72,10 +73,14 @@ if [ "${HISTORY_MODE}" = archive ]; then
         --arg SHA256 "${SHA256}" \
         --arg FILESIZE_BYTES "${FILESIZE_BYTES}" \
         --arg FILESIZE "${FILESIZE}" \
-        --arg TEZOS_VERSION "${TEZOS_VERSION}" \
         --arg NETWORK "${NETWORK}" \
         --arg HISTORY_MODE "archive" \
         --arg ARTIFACT_TYPE "tarball" \
+        --arg TEZOS_VERSION_MAJOR "$(echo "${TEZOS_RPC_VERSION_INFO}" | jq .version.major)" \
+        --arg TEZOS_VERSION_MINOR "$(echo "${TEZOS_RPC_VERSION_INFO}" | jq .version.minor)" \
+        --arg TEZOS_VERSION_ADDITIONAL_INFO "$(echo "${TEZOS_RPC_VERSION_INFO}" | jq .version.additional_info)" \
+        --arg TEZOS_VERSION_COMMIT_HASH "$(echo "${TEZOS_RPC_VERSION_INFO}" | jq .commit_info.commit_hash)" \
+        --arg TEZOS_VERSION_COMMIT_DATE "$(echo "${TEZOS_RPC_VERSION_INFO}" | jq .commit_info.commit_date)" \
         '{
             "block_hash": $BLOCK_HASH, 
             "block_height": $BLOCK_HEIGHT, 
@@ -85,10 +90,20 @@ if [ "${HISTORY_MODE}" = archive ]; then
             "url": $URL,
             "filesize_bytes": $FILESIZE_BYTES,
             "filesize": $FILESIZE, 
-            "tezos_version": $TEZOS_VERSION,
             "chain_name": $NETWORK,
             "history_mode": $HISTORY_MODE,
             "artifact_type": $ARTIFACT_TYPE
+            "tezos_version":{
+                "implementation": "octez",
+                "version": {
+                "major": $TEZOS_VERSION_MAJOR,
+                "minor": $TEZOS_VERSION_MINOR,
+                "additional_info": $TEZOS_VERSION_ADDITIONAL_INFO
+            },
+            "commit_info": {
+                "commit_hash": $TEZOS_VERSION_COMMIT_HASH,
+                "commit_date": $TEZOS_VERSION_COMMIT_DATE
+            }
         }' \
         > "${ARCHIVE_TARBALL_FILENAME}".json
 
@@ -236,10 +251,14 @@ if [ "${HISTORY_MODE}" = rolling ]; then
         --arg SHA256 "$SHA256" \
         --arg FILESIZE_BYTES "$FILESIZE_BYTES" \
         --arg FILESIZE "$FILESIZE" \
-        --arg TEZOS_VERSION "$TEZOS_VERSION" \
         --arg NETWORK "$NETWORK" \
         --arg HISTORY_MODE "rolling" \
         --arg ARTIFACT_TYPE "tarball" \
+        --arg TEZOS_VERSION_MAJOR "$(echo "${TEZOS_RPC_VERSION_INFO}" | jq .version.major)" \
+        --arg TEZOS_VERSION_MINOR "$(echo "${TEZOS_RPC_VERSION_INFO}" | jq .version.minor)" \
+        --arg TEZOS_VERSION_ADDITIONAL_INFO "$(echo "${TEZOS_RPC_VERSION_INFO}" | jq .version.additional_info)" \
+        --arg TEZOS_VERSION_COMMIT_HASH "$(echo "${TEZOS_RPC_VERSION_INFO}" | jq .commit_info.commit_hash)" \
+        --arg TEZOS_VERSION_COMMIT_DATE "$(echo "${TEZOS_RPC_VERSION_INFO}" | jq .commit_info.commit_date)" \
         '{
             "block_hash": $BLOCK_HASH, 
             "block_height": $BLOCK_HEIGHT, 
@@ -253,6 +272,17 @@ if [ "${HISTORY_MODE}" = rolling ]; then
             "chain_name": $NETWORK,
             "history_mode": $HISTORY_MODE,
             "artifact_type": $ARTIFACT_TYPE
+            "tezos_version":{
+                "implementation": "octez",
+                "version": {
+                "major": $TEZOS_VERSION_MAJOR,
+                "minor": $TEZOS_VERSION_MINOR,
+                "additional_info": $TEZOS_VERSION_ADDITIONAL_INFO
+            },
+            "commit_info": {
+                "commit_hash": $TEZOS_VERSION_COMMIT_HASH,
+                "commit_date": $TEZOS_VERSION_COMMIT_DATE
+            }
         }' \
         > "${ROLLING_TARBALL_FILENAME}".json
         
@@ -328,10 +358,14 @@ if [ "${HISTORY_MODE}" = rolling ]; then
             --arg SHA256 "$SHA256" \
             --arg FILESIZE_BYTES "$FILESIZE_BYTES" \
             --arg FILESIZE "$FILESIZE" \
-            --arg TEZOS_VERSION "$TEZOS_VERSION" \
             --arg NETWORK "$NETWORK" \
             --arg HISTORY_MODE "rolling" \
             --arg ARTIFACT_TYPE "tezos-snapshot" \
+            --arg TEZOS_VERSION_MAJOR "$(echo "${TEZOS_RPC_VERSION_INFO}" | jq .version.major)" \
+            --arg TEZOS_VERSION_MINOR "$(echo "${TEZOS_RPC_VERSION_INFO}" | jq .version.minor)" \
+            --arg TEZOS_VERSION_ADDITIONAL_INFO "$(echo "${TEZOS_RPC_VERSION_INFO}" | jq .version.additional_info)" \
+            --arg TEZOS_VERSION_COMMIT_HASH "$(echo "${TEZOS_RPC_VERSION_INFO}" | jq .commit_info.commit_hash)" \
+            --arg TEZOS_VERSION_COMMIT_DATE "$(echo "${TEZOS_RPC_VERSION_INFO}" | jq .commit_info.commit_date)" \
             '{
                 "block_hash": $BLOCK_HASH, 
                 "block_height": $BLOCK_HEIGHT, 
@@ -345,6 +379,17 @@ if [ "${HISTORY_MODE}" = rolling ]; then
                 "chain_name": $NETWORK,
                 "history_mode": $HISTORY_MODE,
                 "artifact_type": $ARTIFACT_TYPE
+                "tezos_version":{
+                    "implementation": "octez",
+                    "version": {
+                    "major": $TEZOS_VERSION_MAJOR,
+                    "minor": $TEZOS_VERSION_MINOR,
+                    "additional_info": $TEZOS_VERSION_ADDITIONAL_INFO
+                },
+                "commit_info": {
+                    "commit_hash": $TEZOS_VERSION_COMMIT_HASH,
+                    "commit_date": $TEZOS_VERSION_COMMIT_DATE
+                }
             }' \
             > "${ROLLING_SNAPSHOT_FILENAME}".json
             


### PR DESCRIPTION
This closes #527 

It was requested to model the metadata after the following -
```json
   {
        "block_hash": "BLyehw7rgqgY9KpQLZuDtoB4Mg83uoETGBLJpS7zS5UUwzRUMdH",
        "block_height": "3010262",
        "block_timestamp": "2022-12-29T05:55:14Z",
        "filename": "tezos-mainnet-rolling-tarball-3010262.lz4",
        "url": "https://mainnet-v15.xtz-shots.io/tezos-mainnet-rolling-tarball-3010262.lz4",
        "sha256": "e55f982c0dfd96b9514a8d94a472c85be1ee4859f0c41aca169891d40bb5f8c6",
        "filesize_bytes": "4385694379",
        "filesize": "4G",
        "chain_name": "mainnet",
        "history_mode": "rolling",
        "artifact_type": "tarball",
        "tezos_version":{
            "implementation": "octez",
            "version": {
                "major": 15,
                "minor": 1,
                "additional_info": "release"
            },
            "commit_info": {
                "commit_hash": "763259c5",
                "commit_date": "2022-12-01 10:20:58 +0000"
            }
        }
    },
```

This switches from our current format of -
```json
    {
        "block_hash": "BKwtkhuQ2WHxgRKDwpQRrib4HHafFLrtMPsA2TudzXz8tYkBaUY",
        "block_height": "3021019",
        "block_timestamp": "2023-01-02T00:50:59Z",
        "filename": "tezos-mainnet-rolling-tarball-3021019.lz4",
        "url": "https://mainnet-v15.xtz-shots.io/tezos-mainnet-rolling-tarball-3021019.lz4",
        "sha256": "9a47b200ab7ec4f87fa289e2eed6675828b6bfbee6427ab6ba5d87bab429c1b5",
        "filesize_bytes": "4399042890",
        "filesize": "4G",
        "tezos_version": "763259c5 (2022-12-01 10:20:58 +0000) (15.1)",
        "chain_name": "mainnet",
        "history_mode": "rolling",
        "artifact_type": "tarball"
    },
```

I confirmed the following with Serokell with regards to tezos-packaging:
* Strings to ints will not help or break their code as they are using Python and their implementation makes no differentiation between the two
* They don't currently use the `tezos_version` field so changing it will not break their app
