### PR TITLE
Exit config-init script on error

### DIFF
--- a/charts/tezos/scripts/config-init.sh
+++ b/charts/tezos/scripts/config-init.sh
@@ -1,8 +1,7 @@
+set -e
+
 echo "Writing custom configuration for public node"
 mkdir -p /etc/tezos/data
-
-#
-# This is my comment.
 
 /usr/local/bin/octez-node config init		\
     --config-file /etc/tezos/data/config.json	\

--- a/test/charts/mainnet.expect.yaml
+++ b/test/charts/mainnet.expect.yaml
@@ -216,11 +216,10 @@ spec:
           args:
             - "-c"
             - |
+              set -e
+              
               echo "Writing custom configuration for public node"
               mkdir -p /etc/tezos/data
-              
-              #
-              # This is my comment.
               
               /usr/local/bin/octez-node config init		\
                   --config-file /etc/tezos/data/config.json	\

--- a/test/charts/mainnet2.expect.yaml
+++ b/test/charts/mainnet2.expect.yaml
@@ -319,11 +319,10 @@ spec:
           args:
             - "-c"
             - |
+              set -e
+              
               echo "Writing custom configuration for public node"
               mkdir -p /etc/tezos/data
-              
-              #
-              # This is my comment.
               
               /usr/local/bin/octez-node config init		\
                   --config-file /etc/tezos/data/config.json	\
@@ -691,11 +690,10 @@ spec:
           args:
             - "-c"
             - |
+              set -e
+              
               echo "Writing custom configuration for public node"
               mkdir -p /etc/tezos/data
-              
-              #
-              # This is my comment.
               
               /usr/local/bin/octez-node config init		\
                   --config-file /etc/tezos/data/config.json	\


### PR DESCRIPTION
We ran into a problem where config-init exited cleanly after running `octez-node config init...` and failed with `(/usr/local/bin/octez-node) Exit: exit because of uncaught exception: Failure("resolution failed: name resolution failed")`. 

`teztnets.xyz` as part of the `--network` flag failed to resolve. The container then moved on to config-generator which failed bec it couldn't find the config.json file as it didn't get written.

The config-init script should exit on error so that k8s retries the container. In the case where the network url didn't resolve at first, it may on a subsequent try.