### PR TITLE
Set fitness to 1 instead of -1 at activation

### DIFF
--- a/charts/tezos/scripts/chain-initiator.sh
+++ b/charts/tezos/scripts/chain-initiator.sh
@@ -15,6 +15,6 @@ echo Activating chain:
 $CLIENT -d /var/tezos/client --block					\
 	genesis activate protocol					\
 	{{ .Values.activation.protocol_hash }}				\
-	with fitness -1 and key						\
+	with fitness 1 and key						\
 	$( cat /etc/tezos/activation_account_name )			\
 	and parameters /etc/tezos/parameters.json 2>&1 | head -200

--- a/test/charts/private-chain.expect.yaml
+++ b/test/charts/private-chain.expect.yaml
@@ -1369,7 +1369,7 @@ spec:
               $CLIENT -d /var/tezos/client --block					\
               	genesis activate protocol					\
               	PtJakart2xVj7pYXJBXrqHgd82rdkLey5ZeeGwDgPp9rhQUbSqY				\
-              	with fitness -1 and key						\
+              	with fitness 1 and key						\
               	$( cat /etc/tezos/activation_account_name )			\
               	and parameters /etc/tezos/parameters.json 2>&1 | head -200
               


### PR DESCRIPTION
A bug was uncovered during mumbai activation, where nodes were unable to activate and were crashing.

The [fix](https://gitlab.com/tezos/tezos/-/merge_requests/7462/diffs) broke dailynet because it is no longer possible to activate with a fitness of -1 (which is how we have been activating chains since the beginning of tezos-k8s).

Replacing this value to 1 fixes the issue for dailynet and also does not appear to be causing any issue with v15.1.