### PR TITLE
mumbai parameters for mkchain

### DIFF
--- a/charts/snapshotEngine/values.yaml
+++ b/charts/snapshotEngine/values.yaml
@@ -3,7 +3,7 @@ tezos_k8s_images:
 
 # the tezos version used to run `octez-node snapshot import/export`
 images:
-  octez: tezos/tezos:v15-release
+  octez: tezos/tezos:v16-release
 
 # snapshotEngine containers interact with the kubernetes control
 # plane to create volume snapshots. This requires a special IAM role

--- a/charts/snapshotEngine/values.yaml
+++ b/charts/snapshotEngine/values.yaml
@@ -3,7 +3,7 @@ tezos_k8s_images:
 
 # the tezos version used to run `octez-node snapshot import/export`
 images:
-  octez: tezos/tezos:v16-release
+  octez: tezos/tezos:v16.1
 
 # snapshotEngine containers interact with the kubernetes control
 # plane to create volume snapshots. This requires a special IAM role

--- a/charts/tezos/values.yaml
+++ b/charts/tezos/values.yaml
@@ -8,7 +8,7 @@ is_invitation: false
 
 # Images not part of the tezos-k8s repo go here
 images:
-  octez: tezos/tezos:v15-release
+  octez: tezos/tezos:v16-release
 # Images that are part of the tezos-k8s repo go here with 'dev' tag
 tezos_k8s_images:
   utils: ghcr.io/oxheadalpha/tezos-k8s-utils:master
@@ -72,7 +72,7 @@ accounts: {}
 #     is_bootstrap_baker_account: false
 #     bootstrap_balance: "4000000000000"
 #     protocols:
-#     - command: PtLimaPt
+#     - command: PtMumbai
 #       vote:
 #         liquidity_baking_toggle_vote: "on"
 # ```
@@ -359,7 +359,7 @@ protocols:
   ##   "on" and "off" must be between quotes.
   ## Note that we are not providing default votes since every baker needs
   ## to make an explicit educated choice on every toggle.
-  - command: PtLimaPt
+  - command: PtMumbai
     vote: {}
   # - command: alpha
   #   vote:
@@ -371,7 +371,7 @@ protocols:
 ## after chain activation.
 ##
 # activation:
-#  protocol_hash: PtLimaPtLMwfNinJi9rCfDPWea8dFgTZ1MeJ9f1m2SRic6ayiwW
+#  protocol_hash: PtMumbai2TmsJHNGRkD8v8YDbtao7BLUC3wjASn1inAKLFCjaH1
 #  protocol_parameters:
 #    preserved_cycles: 3
 #    blocks_per_cycle: 8
@@ -413,7 +413,7 @@ protocols:
 #    cache_sampler_state_cycles: 8
 #    nonce_revelation_threshold: 4
 #    vdf_difficulty: '100000'
-#    tx_rollup_enable: true
+#    tx_rollup_enable: false
 #    tx_rollup_origination_size: 4000
 #    tx_rollup_hard_size_limit_per_inbox: 500000
 #    tx_rollup_hard_size_limit_per_message: 5000
@@ -432,23 +432,24 @@ protocols:
 #      feature_enable: true
 #      number_of_slots: 256
 #      number_of_shards: 2048
-#      endorsement_lag: 2
+#      attestation_lag: 2
 #      availability_threshold: 50
 #      slot_size: 1048576
 #      redundancy_factor: 16
 #      page_size: 4096
-#    sc_rollup_enable: true
-#    sc_rollup_origination_size: 6314
-#    sc_rollup_challenge_window_in_blocks: 40
-#    sc_rollup_stake_amount: "32000000"
-#    sc_rollup_commitment_period_in_blocks: 20
-#    sc_rollup_max_lookahead_in_blocks: 30000
-#    sc_rollup_max_active_outbox_levels: 20160
-#    sc_rollup_max_outbox_messages_per_level: 100
-#    sc_rollup_max_number_of_cemented_commitments: 5
-#    sc_rollup_max_number_of_messages_per_commitment_period: 32765
-#    sc_rollup_number_of_sections_in_dissection: 32
-#    sc_rollup_timeout_period_in_blocks: 500
+#    smart_rollup_enable: true
+#    smart_rollup_origination_size: 6314
+#    smart_rollup_challenge_window_in_blocks: 40
+#    smart_rollup_stake_amount: "32000000"
+#    smart_rollup_commitment_period_in_blocks: 20
+#    smart_rollup_max_lookahead_in_blocks: 30000
+#    smart_rollup_max_active_outbox_levels: 20160
+#    smart_rollup_max_outbox_messages_per_level: 100
+#    smart_rollup_number_of_sections_in_dissection: 32
+#    smart_rollup_timeout_period_in_blocks: 500
+#    smart_rollup_max_number_of_cemented_commitments: 5
+#    smart_rollup_max_number_of_parallel_games: 32
+#    smart_rollup_arith_pvm_enable: true
 #    zk_rollup_enable: true
 #    zk_rollup_origination_size: 4000
 #    zk_rollup_min_pending_to_process: 10

--- a/charts/tezos/values.yaml
+++ b/charts/tezos/values.yaml
@@ -8,7 +8,7 @@ is_invitation: false
 
 # Images not part of the tezos-k8s repo go here
 images:
-  octez: tezos/tezos:v16-release
+  octez: tezos/tezos:v16.1
 # Images that are part of the tezos-k8s repo go here with 'dev' tag
 tezos_k8s_images:
   utils: ghcr.io/oxheadalpha/tezos-k8s-utils:master

--- a/docs/Prerequisites.md
+++ b/docs/Prerequisites.md
@@ -115,7 +115,7 @@ Or, if you prefer, you can build the image using:
 ./scripts/create_docker_image.sh
 ```
 
-This will create an image with a name like `tezos/tezos:v15.0`.
+This will create an image with a name like `tezos/tezos:v16.0`.
 Then you install it thus:
 ```shell
 docker image save <image> | ( eval $(minikube docker-env); docker image load )

--- a/mkchain/README.md
+++ b/mkchain/README.md
@@ -86,7 +86,7 @@ You can explicitly specify some values by:
 |                                  | --number-of-nodes        | Number of non-baking nodes in the cluster                      | 0                       |
 | bootstrap_peers                  | --bootstrap-peers        | Peer ips to connect to                                         | []                      |
 | expected_proof_of_work           | --expected-proof-of-work | Node identity generation difficulty                            | 0                       |
-| images.octez                     | --octez-docker-image     | Version of the Octez docker image to run                       | tezos/tezos:v15-release |
+| images.octez                     | --octez-docker-image     | Version of the Octez docker image to run                       | tezos/tezos:v16-release |
 |                                  | --use-docker (--no...)   | Use (or don't use) docker to generate keys rather than pytezos | autodetect              |
 | zerotier_config.zerotier_network | --zerotier-network       | Zerotier network id for external chain access                  |                         |
 | zerotier_config.zerotier_token   | --zerotier-token         | Zerotier token for external chain access                       |                         |

--- a/mkchain/README.md
+++ b/mkchain/README.md
@@ -86,7 +86,7 @@ You can explicitly specify some values by:
 |                                  | --number-of-nodes        | Number of non-baking nodes in the cluster                      | 0                       |
 | bootstrap_peers                  | --bootstrap-peers        | Peer ips to connect to                                         | []                      |
 | expected_proof_of_work           | --expected-proof-of-work | Node identity generation difficulty                            | 0                       |
-| images.octez                     | --octez-docker-image     | Version of the Octez docker image to run                       | tezos/tezos:v16-release |
+| images.octez                     | --octez-docker-image     | Version of the Octez docker image to run                       | tezos/tezos:v16.1 |
 |                                  | --use-docker (--no...)   | Use (or don't use) docker to generate keys rather than pytezos | autodetect              |
 | zerotier_config.zerotier_network | --zerotier-network       | Zerotier network id for external chain access                  |                         |
 | zerotier_config.zerotier_token   | --zerotier-token         | Zerotier token for external chain access                       |                         |

--- a/mkchain/tqchain/mkchain.py
+++ b/mkchain/tqchain/mkchain.py
@@ -70,7 +70,7 @@ cli_args = {
     },
     "octez_docker_image": {
         "help": "Version of the Octez docker image",
-        "default": "tezos/tezos:v16-release",
+        "default": "tezos/tezos:v16.1",
     },
     "use_docker": {
         "action": "store_true",

--- a/mkchain/tqchain/mkchain.py
+++ b/mkchain/tqchain/mkchain.py
@@ -70,7 +70,7 @@ cli_args = {
     },
     "octez_docker_image": {
         "help": "Version of the Octez docker image",
-        "default": "tezos/tezos:v15-release",
+        "default": "tezos/tezos:v16-release",
     },
     "use_docker": {
         "action": "store_true",
@@ -294,7 +294,7 @@ def main():
         parametersYaml = yaml.safe_load(yaml_file)
         activation = {
             "activation": {
-                "protocol_hash": "PtMumbaiiFFEGbew1rRjzSPyzRbA51Tm3RVZL5suHPxSZYDhCEc",
+                "protocol_hash": "PtMumbai2TmsJHNGRkD8v8YDbtao7BLUC3wjASn1inAKLFCjaH1",
                 "protocol_parameters": parametersYaml,
             },
         }

--- a/mkchain/tqchain/mkchain.py
+++ b/mkchain/tqchain/mkchain.py
@@ -187,7 +187,7 @@ def main():
         },
         "protocols": [
             {
-                "command": "PtLimaPt",
+                "command": "PtMumbai",
                 "vote": {"liquidity_baking_toggle_vote": "pass"},
             }
         ],
@@ -293,7 +293,7 @@ def main():
         parametersYaml = yaml.safe_load(yaml_file)
         activation = {
             "activation": {
-                "protocol_hash": "PtLimaPtLMwfNinJi9rCfDPWea8dFgTZ1MeJ9f1m2SRic6ayiwW",
+                "protocol_hash": "PtMumbaiiFFEGbew1rRjzSPyzRbA51Tm3RVZL5suHPxSZYDhCEc",
                 "protocol_parameters": parametersYaml,
             },
         }

--- a/mkchain/tqchain/parameters.yaml
+++ b/mkchain/tqchain/parameters.yaml
@@ -38,7 +38,7 @@ cache_stake_distribution_cycles: 8
 cache_sampler_state_cycles: 8
 nonce_revelation_threshold: 4
 vdf_difficulty: '100000'
-tx_rollup_enable: true
+tx_rollup_enable: false
 tx_rollup_origination_size: 4000
 tx_rollup_hard_size_limit_per_inbox: 500000
 tx_rollup_hard_size_limit_per_message: 5000
@@ -57,23 +57,24 @@ dal_parametric:
   feature_enable: true
   number_of_slots: 256
   number_of_shards: 2048
-  endorsement_lag: 2
+  attestation_lag: 2
   availability_threshold: 50
   slot_size: 1048576
   redundancy_factor: 16
   page_size: 4096
-sc_rollup_enable: true
-sc_rollup_origination_size: 6314
-sc_rollup_challenge_window_in_blocks: 40
-sc_rollup_stake_amount: "32000000"
-sc_rollup_commitment_period_in_blocks: 20
-sc_rollup_max_lookahead_in_blocks: 30000
-sc_rollup_max_active_outbox_levels: 20160
-sc_rollup_max_outbox_messages_per_level: 100
-sc_rollup_max_number_of_cemented_commitments: 5
-sc_rollup_max_number_of_messages_per_commitment_period: 32765
-sc_rollup_number_of_sections_in_dissection: 32
-sc_rollup_timeout_period_in_blocks: 500
+smart_rollup_enable: true
+smart_rollup_origination_size: 6314
+smart_rollup_challenge_window_in_blocks: 40
+smart_rollup_stake_amount: "32000000"
+smart_rollup_commitment_period_in_blocks: 20
+smart_rollup_max_lookahead_in_blocks: 30000
+smart_rollup_max_active_outbox_levels: 20160
+smart_rollup_max_outbox_messages_per_level: 100
+smart_rollup_number_of_sections_in_dissection: 32
+smart_rollup_timeout_period_in_blocks: 500
+smart_rollup_max_number_of_cemented_commitments: 5
+smart_rollup_max_number_of_parallel_games: 32
+smart_rollup_arith_pvm_enable: true
 zk_rollup_enable: true
 zk_rollup_origination_size: 4000
 zk_rollup_min_pending_to_process: 10

--- a/snapshotEngine/mainJob.yaml
+++ b/snapshotEngine/mainJob.yaml
@@ -190,13 +190,8 @@ spec:
                 --config-file /home/tezos/.tezos-node/config.json \
                 --data-dir /rolling-tarball-restore/var/tezos/node/data
 
-                # Version check for v15 vs v16 conditional
-                TEZOS_VERSION=$(cat /"${HISTORY_MODE}"-snapshot-cache-volume/TEZOS_VERSION)
-                
-                # Get context elements and octez snapshot version
-                if [[ "$TEZOS_VERSION" != '763259c5 (2022-12-01 10:20:58 +0000) (15.1)' ]]; then
-                  /usr/local/bin/octez-node snapshot info /"${HISTORY_MODE}"-snapshot-cache-volume/"${ROLLING_SNAPSHOT_NAME}".rolling --json > /"${HISTORY_MODE}"-snapshot-cache-volume/SNAPSHOT_HEADER
-                fi
+                # Get octez snapshot version
+                /usr/local/bin/octez-node snapshot info /"${HISTORY_MODE}"-snapshot-cache-volume/"${ROLLING_SNAPSHOT_NAME}".rolling --json > /"${HISTORY_MODE}"-snapshot-cache-volume/SNAPSHOT_HEADER
 
                 rm /rolling-tarball-restore/snapshot-import-in-progress
               else

--- a/test/charts/mainnet.expect.yaml
+++ b/test/charts/mainnet.expect.yaml
@@ -33,7 +33,7 @@ data:
   ARCHIVE_TARBALL_URL: ""
   PREFER_TARBALLS: "false"
   SNAPSHOT_SOURCE: "https://xtz-shots.io/tezos-snapshots.json"
-  OCTEZ_VERSION: "tezos/tezos:v16-release"
+  OCTEZ_VERSION: "tezos/tezos:v16.1"
   NODE_GLOBALS: |
     {
       "env": {}
@@ -124,7 +124,7 @@ spec:
     spec:
       containers:        
         - name: octez-node
-          image: "tezos/tezos:v16-release"
+          image: "tezos/tezos:v16.1"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -209,7 +209,7 @@ spec:
               memory: 80Mi        
       initContainers:        
         - name: config-init
-          image: "tezos/tezos:v16-release"
+          image: "tezos/tezos:v16.1"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -312,7 +312,7 @@ spec:
             - mountPath: /var/tezos
               name: var-volume        
         - name: snapshot-importer
-          image: "tezos/tezos:v16-release"
+          image: "tezos/tezos:v16.1"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -375,7 +375,7 @@ spec:
             - mountPath: /var/tezos
               name: var-volume                
         - name: upgrade-storage
-          image: "tezos/tezos:v16-release"
+          image: "tezos/tezos:v16.1"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh

--- a/test/charts/mainnet.expect.yaml
+++ b/test/charts/mainnet.expect.yaml
@@ -33,7 +33,7 @@ data:
   ARCHIVE_TARBALL_URL: ""
   PREFER_TARBALLS: "false"
   SNAPSHOT_SOURCE: "https://xtz-shots.io/tezos-snapshots.json"
-  OCTEZ_VERSION: "tezos/tezos:v15-release"
+  OCTEZ_VERSION: "tezos/tezos:v16-release"
   NODE_GLOBALS: |
     {
       "env": {}
@@ -124,7 +124,7 @@ spec:
     spec:
       containers:        
         - name: octez-node
-          image: "tezos/tezos:v15-release"
+          image: "tezos/tezos:v16-release"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -209,7 +209,7 @@ spec:
               memory: 80Mi        
       initContainers:        
         - name: config-init
-          image: "tezos/tezos:v15-release"
+          image: "tezos/tezos:v16-release"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -312,7 +312,7 @@ spec:
             - mountPath: /var/tezos
               name: var-volume        
         - name: snapshot-importer
-          image: "tezos/tezos:v15-release"
+          image: "tezos/tezos:v16-release"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -375,7 +375,7 @@ spec:
             - mountPath: /var/tezos
               name: var-volume                
         - name: upgrade-storage
-          image: "tezos/tezos:v15-release"
+          image: "tezos/tezos:v16-release"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh

--- a/test/charts/mainnet2.expect.yaml
+++ b/test/charts/mainnet2.expect.yaml
@@ -33,7 +33,7 @@ data:
   ARCHIVE_TARBALL_URL: ""
   PREFER_TARBALLS: "false"
   SNAPSHOT_SOURCE: "https://xtz-shots.io/tezos-snapshots.json"
-  OCTEZ_VERSION: "tezos/tezos:v16-release"
+  OCTEZ_VERSION: "tezos/tezos:v16.1"
   NODE_GLOBALS: |
     {
       "env": {
@@ -191,7 +191,7 @@ spec:
     spec:
       containers:        
         - name: octez-node
-          image: "tezos/tezos:v16-release"
+          image: "tezos/tezos:v16.1"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -312,7 +312,7 @@ spec:
               memory: 80Mi        
       initContainers:        
         - name: config-init
-          image: "tezos/tezos:v16-release"
+          image: "tezos/tezos:v16.1"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -421,7 +421,7 @@ spec:
             - mountPath: /var/tezos
               name: var-volume        
         - name: snapshot-importer
-          image: "tezos/tezos:v16-release"
+          image: "tezos/tezos:v16.1"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -486,7 +486,7 @@ spec:
             - mountPath: /var/tezos
               name: var-volume                
         - name: upgrade-storage
-          image: "tezos/tezos:v16-release"
+          image: "tezos/tezos:v16.1"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh

--- a/test/charts/mainnet2.expect.yaml
+++ b/test/charts/mainnet2.expect.yaml
@@ -33,7 +33,7 @@ data:
   ARCHIVE_TARBALL_URL: ""
   PREFER_TARBALLS: "false"
   SNAPSHOT_SOURCE: "https://xtz-shots.io/tezos-snapshots.json"
-  OCTEZ_VERSION: "tezos/tezos:v15-release"
+  OCTEZ_VERSION: "tezos/tezos:v16-release"
   NODE_GLOBALS: |
     {
       "env": {
@@ -191,7 +191,7 @@ spec:
     spec:
       containers:        
         - name: octez-node
-          image: "tezos/tezos:v15-release"
+          image: "tezos/tezos:v16-release"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -312,7 +312,7 @@ spec:
               memory: 80Mi        
       initContainers:        
         - name: config-init
-          image: "tezos/tezos:v15-release"
+          image: "tezos/tezos:v16-release"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -421,7 +421,7 @@ spec:
             - mountPath: /var/tezos
               name: var-volume        
         - name: snapshot-importer
-          image: "tezos/tezos:v15-release"
+          image: "tezos/tezos:v16-release"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -486,7 +486,7 @@ spec:
             - mountPath: /var/tezos
               name: var-volume                
         - name: upgrade-storage
-          image: "tezos/tezos:v15-release"
+          image: "tezos/tezos:v16-release"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh


### PR DESCRIPTION
As usual:

* mkchain chain gets activated using mumbai proposal
* bump version by default to v16

The `v16-release` tag was removed by octez so we currently hardcode v16.1. I [opened a ticket](https://gitlab.com/tezos/tezos/-/issues/5233).