### PR TITLE
Persist identity and peers when using local storage

### DIFF
--- a/charts/tezos/scripts/snapshot-importer.sh
+++ b/charts/tezos/scripts/snapshot-importer.sh
@@ -12,7 +12,7 @@ if [ ! -f ${snapshot_file} ]; then
     exit 0
 fi
 
-if [ -d ${node_data_dir}/context ]; then
+if [ -d ${node_data_dir}/context/store.dict ]; then
     echo "Blockchain has already been imported. If a tarball"
     echo "instead of a regular tezos snapshot was used, it was"
     echo "imported in the snapshot-downloader container."

--- a/charts/tezos/scripts/snapshot-importer.sh
+++ b/charts/tezos/scripts/snapshot-importer.sh
@@ -12,7 +12,7 @@ if [ ! -f ${snapshot_file} ]; then
     exit 0
 fi
 
-if [ -d ${node_data_dir}/context/store.dict ]; then
+if [ -e ${node_data_dir}/context/store.dict ]; then
     echo "Blockchain has already been imported. If a tarball"
     echo "instead of a regular tezos snapshot was used, it was"
     echo "imported in the snapshot-downloader container."

--- a/charts/tezos/scripts/upgrade-storage.sh
+++ b/charts/tezos/scripts/upgrade-storage.sh
@@ -1,6 +1,6 @@
 set -ex
 
-if [ ! -e /var/tezos/node/data/context ]
+if [ ! -e /var/tezos/node/data/context/store.dict ]
 then
   printf "No context in data dir found, probably initial start, doing nothing."
   exit 0

--- a/charts/tezos/scripts/upgrade-storage.sh
+++ b/charts/tezos/scripts/upgrade-storage.sh
@@ -2,7 +2,7 @@ set -ex
 
 if [ ! -e /var/tezos/node/data/context/store.dict ]
 then
-  printf "No context in data dir found, probably initial start, doing nothing."
+  printf "No store in data dir found, probably initial start, doing nothing."
   exit 0
 fi
 octez-node upgrade storage --config /etc/tezos/config.json

--- a/charts/tezos/templates/_containers.tpl
+++ b/charts/tezos/templates/_containers.tpl
@@ -150,6 +150,10 @@
       name: config-volume
     - mountPath: /var/tezos
       name: var-volume
+    {{- if .local_storage }}
+    - mountPath: /var/persistent
+      name: persistent-volume
+    {{- end }}
     {{- if .with_secret }}
     - mountPath: /etc/secret-volume
       name: tezos-accounts
@@ -264,6 +268,7 @@
                                                 "type"        "octez-node"
                                                 "image"       "octez"
                                                 "with_config" 0
+                                                "local_storage" $.node_vals.local_storage
                                                 "resources"   $.node_vals.resources
     ) | nindent 0 }}
 {{- end }}

--- a/charts/tezos/templates/nodes.yaml
+++ b/charts/tezos/templates/nodes.yaml
@@ -70,6 +70,8 @@ spec:
   volumeClaimTemplates:
     - metadata:
 {{- if $.node_vals.local_storage | default false }}
+        # since we are using local storage, deploy a small persistent voluem
+        # to store identity.json and peers.json
         name: persistent-volume
 {{- else }}
         name: var-volume

--- a/charts/tezos/templates/nodes.yaml
+++ b/charts/tezos/templates/nodes.yaml
@@ -70,7 +70,7 @@ spec:
   volumeClaimTemplates:
     - metadata:
 {{- if $.node_vals.local_storage | default false }}
-        # since we are using local storage, deploy a small persistent voluem
+        # since we are using local storage, deploy a small persistent volume
         # to store identity.json and peers.json
         name: persistent-volume
 {{- else }}

--- a/charts/tezos/templates/nodes.yaml
+++ b/charts/tezos/templates/nodes.yaml
@@ -66,10 +66,14 @@ spec:
 {{- if $.node_vals.local_storage | default false }}
         - emptyDir: {}
           name: var-volume
-{{- else }}
+{{- end }}
   volumeClaimTemplates:
     - metadata:
+{{- if $.node_vals.local_storage | default false }}
+        name: persistent-volume
+{{- else }}
         name: var-volume
+{{- end }}
         namespace: {{ $.Release.Namespace }}
       spec:
         accessModes:
@@ -79,6 +83,9 @@ spec:
         {{- end }}
         resources:
           requests:
+{{- if $.node_vals.local_storage | default false }}
+            storage: "1Gi"
+{{- else }}
             storage: {{ default "15Gi" $.node_vals.storage_size }}
 {{- end }}
 ---

--- a/test/charts/mainnet.expect.yaml
+++ b/test/charts/mainnet.expect.yaml
@@ -386,7 +386,7 @@ spec:
               
               if [ ! -e /var/tezos/node/data/context/store.dict ]
               then
-                printf "No context in data dir found, probably initial start, doing nothing."
+                printf "No store in data dir found, probably initial start, doing nothing."
                 exit 0
               fi
               octez-node upgrade storage --config /etc/tezos/config.json

--- a/test/charts/mainnet.expect.yaml
+++ b/test/charts/mainnet.expect.yaml
@@ -333,7 +333,7 @@ spec:
                   exit 0
               fi
               
-              if [ -d ${node_data_dir}/context/store.dict ]; then
+              if [ -e ${node_data_dir}/context/store.dict ]; then
                   echo "Blockchain has already been imported. If a tarball"
                   echo "instead of a regular tezos snapshot was used, it was"
                   echo "imported in the snapshot-downloader container."

--- a/test/charts/mainnet.expect.yaml
+++ b/test/charts/mainnet.expect.yaml
@@ -333,7 +333,7 @@ spec:
                   exit 0
               fi
               
-              if [ -d ${node_data_dir}/context ]; then
+              if [ -d ${node_data_dir}/context/store.dict ]; then
                   echo "Blockchain has already been imported. If a tarball"
                   echo "instead of a regular tezos snapshot was used, it was"
                   echo "imported in the snapshot-downloader container."
@@ -384,7 +384,7 @@ spec:
             - |
               set -ex
               
-              if [ ! -e /var/tezos/node/data/context ]
+              if [ ! -e /var/tezos/node/data/context/store.dict ]
               then
                 printf "No context in data dir found, probably initial start, doing nothing."
                 exit 0

--- a/test/charts/mainnet2.expect.yaml
+++ b/test/charts/mainnet2.expect.yaml
@@ -497,7 +497,7 @@ spec:
               
               if [ ! -e /var/tezos/node/data/context/store.dict ]
               then
-                printf "No context in data dir found, probably initial start, doing nothing."
+                printf "No store in data dir found, probably initial start, doing nothing."
                 exit 0
               fi
               octez-node upgrade storage --config /etc/tezos/config.json
@@ -867,7 +867,7 @@ spec:
               
               if [ ! -e /var/tezos/node/data/context/store.dict ]
               then
-                printf "No context in data dir found, probably initial start, doing nothing."
+                printf "No store in data dir found, probably initial start, doing nothing."
                 exit 0
               fi
               octez-node upgrade storage --config /etc/tezos/config.json

--- a/test/charts/mainnet2.expect.yaml
+++ b/test/charts/mainnet2.expect.yaml
@@ -442,7 +442,7 @@ spec:
                   exit 0
               fi
               
-              if [ -d ${node_data_dir}/context/store.dict ]; then
+              if [ -e ${node_data_dir}/context/store.dict ]; then
                   echo "Blockchain has already been imported. If a tarball"
                   echo "instead of a regular tezos snapshot was used, it was"
                   echo "imported in the snapshot-downloader container."
@@ -812,7 +812,7 @@ spec:
                   exit 0
               fi
               
-              if [ -d ${node_data_dir}/context/store.dict ]; then
+              if [ -e ${node_data_dir}/context/store.dict ]; then
                   echo "Blockchain has already been imported. If a tarball"
                   echo "instead of a regular tezos snapshot was used, it was"
                   echo "imported in the snapshot-downloader container."

--- a/test/charts/mainnet2.expect.yaml
+++ b/test/charts/mainnet2.expect.yaml
@@ -442,7 +442,7 @@ spec:
                   exit 0
               fi
               
-              if [ -d ${node_data_dir}/context ]; then
+              if [ -d ${node_data_dir}/context/store.dict ]; then
                   echo "Blockchain has already been imported. If a tarball"
                   echo "instead of a regular tezos snapshot was used, it was"
                   echo "imported in the snapshot-downloader container."
@@ -495,7 +495,7 @@ spec:
             - |
               set -ex
               
-              if [ ! -e /var/tezos/node/data/context ]
+              if [ ! -e /var/tezos/node/data/context/store.dict ]
               then
                 printf "No context in data dir found, probably initial start, doing nothing."
                 exit 0
@@ -812,7 +812,7 @@ spec:
                   exit 0
               fi
               
-              if [ -d ${node_data_dir}/context ]; then
+              if [ -d ${node_data_dir}/context/store.dict ]; then
                   echo "Blockchain has already been imported. If a tarball"
                   echo "instead of a regular tezos snapshot was used, it was"
                   echo "imported in the snapshot-downloader container."
@@ -865,7 +865,7 @@ spec:
             - |
               set -ex
               
-              if [ ! -e /var/tezos/node/data/context ]
+              if [ ! -e /var/tezos/node/data/context/store.dict ]
               then
                 printf "No context in data dir found, probably initial start, doing nothing."
                 exit 0

--- a/test/charts/private-chain.expect.yaml
+++ b/test/charts/private-chain.expect.yaml
@@ -442,7 +442,7 @@ spec:
               
               if [ ! -e /var/tezos/node/data/context/store.dict ]
               then
-                printf "No context in data dir found, probably initial start, doing nothing."
+                printf "No store in data dir found, probably initial start, doing nothing."
                 exit 0
               fi
               octez-node upgrade storage --config /etc/tezos/config.json
@@ -1015,7 +1015,7 @@ spec:
               
               if [ ! -e /var/tezos/node/data/context/store.dict ]
               then
-                printf "No context in data dir found, probably initial start, doing nothing."
+                printf "No store in data dir found, probably initial start, doing nothing."
                 exit 0
               fi
               octez-node upgrade storage --config /etc/tezos/config.json
@@ -1219,7 +1219,7 @@ spec:
               
               if [ ! -e /var/tezos/node/data/context/store.dict ]
               then
-                printf "No context in data dir found, probably initial start, doing nothing."
+                printf "No store in data dir found, probably initial start, doing nothing."
                 exit 0
               fi
               octez-node upgrade storage --config /etc/tezos/config.json

--- a/test/charts/private-chain.expect.yaml
+++ b/test/charts/private-chain.expect.yaml
@@ -441,7 +441,7 @@ spec:
             - |
               set -ex
               
-              if [ ! -e /var/tezos/node/data/context ]
+              if [ ! -e /var/tezos/node/data/context/store.dict ]
               then
                 printf "No context in data dir found, probably initial start, doing nothing."
                 exit 0
@@ -1009,7 +1009,7 @@ spec:
             - |
               set -ex
               
-              if [ ! -e /var/tezos/node/data/context ]
+              if [ ! -e /var/tezos/node/data/context/store.dict ]
               then
                 printf "No context in data dir found, probably initial start, doing nothing."
                 exit 0
@@ -1213,7 +1213,7 @@ spec:
             - |
               set -ex
               
-              if [ ! -e /var/tezos/node/data/context ]
+              if [ ! -e /var/tezos/node/data/context/store.dict ]
               then
                 printf "No context in data dir found, probably initial start, doing nothing."
                 exit 0

--- a/utils/config-generator.sh
+++ b/utils/config-generator.sh
@@ -6,6 +6,7 @@ cat /etc/tezos/data/config.json
 echo ------------------------------------------------------------
 
 mkdir -p /var/tezos/client
+mkdir -p /var/tezos/node/data
 chmod -R 777 /var/tezos
 set -e
 python3 /config-generator.py "$@"
@@ -17,6 +18,17 @@ set +e
 # tezos docker image.
 
 MY_CLASS=$(echo $NODES | jq -r ".\"${MY_NODE_CLASS}\"")
+
+# Set up symlinks for local storage
+local_storage=$(echo $MY_CLASS | jq -r ".local_storage")
+if [ "${local_storage}" == "true" ]; then
+  echo '{ "version": "2.0" }' > /var/tezos/node/data/version.json
+  ln -s /var/persistent/peers.json /var/tezos/node/data/peers.json
+  ln -s /var/persistent/identity.json /var/tezos/node/data/identity.json
+  chmod -R 777 /var/tezos/node/data
+  chmod -R 777 /var/persistent
+fi
+
 AM_I_BAKER=0
 if [ "$MY_CLASS" != null ]; then
     AM_I_BAKER=$(echo $MY_CLASS | \

--- a/utils/config-generator.sh
+++ b/utils/config-generator.sh
@@ -48,3 +48,6 @@ if [ "$AM_I_BAKER" -eq 1 ]; then
 
     echo "$my_baker_account" > /etc/tezos/baker-account
 fi
+
+# make sure tezos user owns everything in /var/tezos
+chown -R 1000:1000 /var/tezos

--- a/utils/config-generator.sh
+++ b/utils/config-generator.sh
@@ -7,7 +7,6 @@ echo ------------------------------------------------------------
 
 mkdir -p /var/tezos/client
 mkdir -p /var/tezos/node/data
-chmod -R 777 /var/tezos
 set -e
 python3 /config-generator.py "$@"
 set +e
@@ -25,8 +24,6 @@ if [ "${local_storage}" == "true" ]; then
   echo '{ "version": "2.0" }' > /var/tezos/node/data/version.json
   ln -s /var/persistent/peers.json /var/tezos/node/data/peers.json
   ln -s /var/persistent/identity.json /var/tezos/node/data/identity.json
-  chmod -R 777 /var/tezos/node/data
-  chmod -R 777 /var/persistent
 fi
 
 AM_I_BAKER=0

--- a/utils/snapshot-downloader.sh
+++ b/utils/snapshot-downloader.sh
@@ -12,7 +12,7 @@ if [ ! -d "$data_dir" ]; then
   exit 1
 fi
 
-if [ -d "$node_data_dir/context/store.dict" ]; then
+if [ -e "$node_data_dir/context/store.dict" ]; then
   echo "Blockchain has already been imported. Exiting."
   exit 0
 fi

--- a/utils/snapshot-downloader.sh
+++ b/utils/snapshot-downloader.sh
@@ -12,7 +12,7 @@ if [ ! -d "$data_dir" ]; then
   exit 1
 fi
 
-if [ -d "$node_data_dir/context" ]; then
+if [ -d "$node_data_dir/context/store.dict" ]; then
   echo "Blockchain has already been imported. Exiting."
   exit 0
 fi


### PR DESCRIPTION
Local storage is great because it's faster, and we can download tarball in minutes at every boot and have tolerable downtimes.

But at each boot, the node regenerates its identity. We already have a mechanism to pre-populate identities in the node yaml, but it's cumbersome.

Instead, with this PR, we create a mini-pvc of 1Gi to store node identities, whenever local storage is in use.

This way, local storage nodes always boot quickly, except the first time they boot, and there is no configuration burden. It is also possible to scale up the number of nodes without having to prepare identities.

This works by creating dangling symlinks in the newly created data dir for both files identity.json and peers.json, targeting the small persistent dir whenever local storage is used. When the node boots, it follows these symlinks and creates files at the target. (I have actually not seen this happen for peers.json but it works for identity.json).

I tested private chain and ghostnet node, in both local and non-local storage. It behaves as intended. I also tried to pre-populate an identity in the values file in local storage and confirmed that it is not broken.
