### PR TITLE
Network argument is broken so we're removing it

### DIFF
--- a/charts/tezos/scripts/snapshot-importer.sh
+++ b/charts/tezos/scripts/snapshot-importer.sh
@@ -25,8 +25,7 @@ if [ -f ${node_dir}/chain.snapshot.block_hash ]; then
     block_hash_arg="--block $(cat ${node_dir}/chain.snapshot.block_hash)"
 fi
 
-${node} snapshot import ${snapshot_file} --data-dir ${node_data_dir} \
-    --network $CHAIN_NAME ${block_hash_arg}
+${node} snapshot import ${snapshot_file} --data-dir ${node_data_dir}
 find ${node_dir}
 
 rm -rvf ${snapshot_file}

--- a/test/charts/mainnet.expect.yaml
+++ b/test/charts/mainnet.expect.yaml
@@ -346,8 +346,7 @@ spec:
                   block_hash_arg="--block $(cat ${node_dir}/chain.snapshot.block_hash)"
               fi
               
-              ${node} snapshot import ${snapshot_file} --data-dir ${node_data_dir} \
-                  --network $CHAIN_NAME ${block_hash_arg}
+              ${node} snapshot import ${snapshot_file} --data-dir ${node_data_dir}
               find ${node_dir}
               
               rm -rvf ${snapshot_file}

--- a/test/charts/mainnet2.expect.yaml
+++ b/test/charts/mainnet2.expect.yaml
@@ -455,8 +455,7 @@ spec:
                   block_hash_arg="--block $(cat ${node_dir}/chain.snapshot.block_hash)"
               fi
               
-              ${node} snapshot import ${snapshot_file} --data-dir ${node_data_dir} \
-                  --network $CHAIN_NAME ${block_hash_arg}
+              ${node} snapshot import ${snapshot_file} --data-dir ${node_data_dir}
               find ${node_dir}
               
               rm -rvf ${snapshot_file}
@@ -826,8 +825,7 @@ spec:
                   block_hash_arg="--block $(cat ${node_dir}/chain.snapshot.block_hash)"
               fi
               
-              ${node} snapshot import ${snapshot_file} --data-dir ${node_data_dir} \
-                  --network $CHAIN_NAME ${block_hash_arg}
+              ${node} snapshot import ${snapshot_file} --data-dir ${node_data_dir}
               find ${node_dir}
               
               rm -rvf ${snapshot_file}


### PR DESCRIPTION
`--network` has been retired as of v16 and it is redundant to `--data-dir`. We've tested it on both v15 and v16 and the omission of this does not break backwards compatability.