### PR TITLE
Use native logging instead of print the error message again

### DIFF
--- a/utils/sidecar.py
+++ b/utils/sidecar.py
@@ -46,7 +46,7 @@ def sync_checker():
             % (age_in_secs, AGE_LIMIT_IN_SECS),
             500,
         )
-        print(err)
+        application.logger.error(err)
         return err
     return "Chain is bootstrapped"
 


### PR DESCRIPTION
original usage of logger was changed to print by this commit
https://github.com/oxheadalpha/tezos-k8s/commit/c837cacd9ad01573f175535c8ec8b9b835f695a3#diff-06e9c476e5103458bda025d8f6beac772713d2d4466985ae3752b672b7a9c0eaL49
I think this is not intentional, so I create this PR to change it back again.