### PR TITLE
per-baker toggle vote customization

### DIFF
--- a/charts/tezos/scripts/baker.sh
+++ b/charts/tezos/scripts/baker.sh
@@ -9,7 +9,10 @@ BAKER_EXTRA_ARGS_FROM_ENV=${BAKER_EXTRA_ARGS}
 
 proto_command="{{ .command_in_tpl }}"
 
-per_block_vote_file=/etc/tezos/per-block-votes/${proto_command}-per-block-votes.json
+my_baker_account="$(sed -n "$(($BAKER_INDEX + 1))p" < /etc/tezos/baker-account )"
+
+per_block_vote_file=/etc/tezos/per-block-votes/${my_baker_account}-${proto_command}-per-block-votes.json
+
 if [ $(cat $per_block_vote_file) == "null" ]; then
   cat << EOF
 You must pass per-block-votes (such as liquidity_baking_toggle_vote) in values.yaml, for example:
@@ -21,8 +24,6 @@ EOF
   exit 1
 fi
 extra_args="--votefile ${per_block_vote_file}"
-
-my_baker_account="$(sed -n "$(($BAKER_INDEX + 1))p" < /etc/tezos/baker-account )"
 
 if [ "${my_baker_account}" == "" ]; then
   while true; do

--- a/charts/tezos/templates/configs.yaml
+++ b/charts/tezos/templates/configs.yaml
@@ -76,8 +76,10 @@ metadata:
 {{- if (include "tezos.hasPerBlockVotes" .) }}
 apiVersion: v1
 data:
-{{- range .Values.protocols }}
-  {{ .command }}-per-block-votes.json: {{ .vote | toJson | quote }}
+{{- range $k, $v := .Values.accounts }}
+{{- range ( $v.protocols | default $.Values.protocols ) }}
+  {{ $k }}-{{ .command }}-per-block-votes.json: {{ .vote | toJson | quote }}
+{{- end }}
 {{- end }}
 kind: ConfigMap
 metadata:

--- a/charts/tezos/values.yaml
+++ b/charts/tezos/values.yaml
@@ -38,7 +38,8 @@ bootstrap_mutez: "4000000000000"
 accounts: {}
 #
 # `accounts` is a map where keys are account aliases and values are maps of
-# fields `key`, `is_bootstrap_baker_account`, `bootstrap_balance` and `signer_url`.
+# fields `key`, `is_bootstrap_baker_account`, `bootstrap_balance`, `signer_url`
+# and `protocols`.
 #
 # The `key` field can be set to a public or private key. For a bootstrap baker,
 # it must be set to a private key. The key type will be recognized automatically,
@@ -53,6 +54,10 @@ accounts: {}
 #   node but they will not be bootstrap accounts. If you don't set a bootstrap
 #   balance, it will default to the `bootstrap_mutez` field above.
 #
+# The `protocols` fields overrides the top-level `protocols` field described
+# below and has the same syntax. This allows to set specific per-block votes per
+# baker.
+#
 # Example:
 #
 # ```
@@ -66,6 +71,10 @@ accounts: {}
 #     key: edpk...
 #     is_bootstrap_baker_account: false
 #     bootstrap_balance: "4000000000000"
+#     protocols:
+#     - command: PtLimaPt
+#       vote:
+#         liquidity_baking_toggle_vote: "on"
 # ```
 #
 # A public key account can contain a url to a remote signer that signs with the

--- a/test/charts/private-chain.expect.yaml
+++ b/test/charts/private-chain.expect.yaml
@@ -186,7 +186,6 @@ metadata:
 # Source: tezos-chain/templates/configs.yaml
 apiVersion: v1
 data:
-  013-PtJakart-per-block-votes.json: "{\"liquidity_baking_toggle_vote\":\"pass\"}"
 kind: ConfigMap
 metadata:
   name: per-block-votes
@@ -575,7 +574,10 @@ spec:
               
               proto_command="013-PtJakart"
               
-              per_block_vote_file=/etc/tezos/per-block-votes/${proto_command}-per-block-votes.json
+              my_baker_account="$(sed -n "$(($BAKER_INDEX + 1))p" < /etc/tezos/baker-account )"
+              
+              per_block_vote_file=/etc/tezos/per-block-votes/${my_baker_account}-${proto_command}-per-block-votes.json
+              
               if [ $(cat $per_block_vote_file) == "null" ]; then
                 cat << EOF
               You must pass per-block-votes (such as liquidity_baking_toggle_vote) in values.yaml, for example:
@@ -587,8 +589,6 @@ spec:
                 exit 1
               fi
               extra_args="--votefile ${per_block_vote_file}"
-              
-              my_baker_account="$(sed -n "$(($BAKER_INDEX + 1))p" < /etc/tezos/baker-account )"
               
               if [ "${my_baker_account}" == "" ]; then
                 while true; do
@@ -642,7 +642,10 @@ spec:
               
               proto_command="013-PtJakart"
               
-              per_block_vote_file=/etc/tezos/per-block-votes/${proto_command}-per-block-votes.json
+              my_baker_account="$(sed -n "$(($BAKER_INDEX + 1))p" < /etc/tezos/baker-account )"
+              
+              per_block_vote_file=/etc/tezos/per-block-votes/${my_baker_account}-${proto_command}-per-block-votes.json
+              
               if [ $(cat $per_block_vote_file) == "null" ]; then
                 cat << EOF
               You must pass per-block-votes (such as liquidity_baking_toggle_vote) in values.yaml, for example:
@@ -654,8 +657,6 @@ spec:
                 exit 1
               fi
               extra_args="--votefile ${per_block_vote_file}"
-              
-              my_baker_account="$(sed -n "$(($BAKER_INDEX + 1))p" < /etc/tezos/baker-account )"
               
               if [ "${my_baker_account}" == "" ]; then
                 while true; do
@@ -709,7 +710,10 @@ spec:
               
               proto_command="013-PtJakart"
               
-              per_block_vote_file=/etc/tezos/per-block-votes/${proto_command}-per-block-votes.json
+              my_baker_account="$(sed -n "$(($BAKER_INDEX + 1))p" < /etc/tezos/baker-account )"
+              
+              per_block_vote_file=/etc/tezos/per-block-votes/${my_baker_account}-${proto_command}-per-block-votes.json
+              
               if [ $(cat $per_block_vote_file) == "null" ]; then
                 cat << EOF
               You must pass per-block-votes (such as liquidity_baking_toggle_vote) in values.yaml, for example:
@@ -721,8 +725,6 @@ spec:
                 exit 1
               fi
               extra_args="--votefile ${per_block_vote_file}"
-              
-              my_baker_account="$(sed -n "$(($BAKER_INDEX + 1))p" < /etc/tezos/baker-account )"
               
               if [ "${my_baker_account}" == "" ]; then
                 while true; do
@@ -776,7 +778,10 @@ spec:
               
               proto_command="013-PtJakart"
               
-              per_block_vote_file=/etc/tezos/per-block-votes/${proto_command}-per-block-votes.json
+              my_baker_account="$(sed -n "$(($BAKER_INDEX + 1))p" < /etc/tezos/baker-account )"
+              
+              per_block_vote_file=/etc/tezos/per-block-votes/${my_baker_account}-${proto_command}-per-block-votes.json
+              
               if [ $(cat $per_block_vote_file) == "null" ]; then
                 cat << EOF
               You must pass per-block-votes (such as liquidity_baking_toggle_vote) in values.yaml, for example:
@@ -788,8 +793,6 @@ spec:
                 exit 1
               fi
               extra_args="--votefile ${per_block_vote_file}"
-              
-              my_baker_account="$(sed -n "$(($BAKER_INDEX + 1))p" < /etc/tezos/baker-account )"
               
               if [ "${my_baker_account}" == "" ]; then
                 while true; do
@@ -843,7 +846,10 @@ spec:
               
               proto_command="013-PtJakart"
               
-              per_block_vote_file=/etc/tezos/per-block-votes/${proto_command}-per-block-votes.json
+              my_baker_account="$(sed -n "$(($BAKER_INDEX + 1))p" < /etc/tezos/baker-account )"
+              
+              per_block_vote_file=/etc/tezos/per-block-votes/${my_baker_account}-${proto_command}-per-block-votes.json
+              
               if [ $(cat $per_block_vote_file) == "null" ]; then
                 cat << EOF
               You must pass per-block-votes (such as liquidity_baking_toggle_vote) in values.yaml, for example:
@@ -855,8 +861,6 @@ spec:
                 exit 1
               fi
               extra_args="--votefile ${per_block_vote_file}"
-              
-              my_baker_account="$(sed -n "$(($BAKER_INDEX + 1))p" < /etc/tezos/baker-account )"
               
               if [ "${my_baker_account}" == "" ]; then
                 while true; do


### PR DESCRIPTION
This allows a baking tezos-k8s setup to customize votes per baker.

Until now, the per-baker votes are set under the `protocols:` object of values.yaml. The votes are listed per prototol and apply to all bakers.

You can now pass a similar `protocols:` object to each account under the `accounts:` object of values.yaml. It will override the global config.

I tried on minikube with 2 bakers, with or without customization of the votes. I observed in the baker logs that the toggles were as expected.