### PR TITLE
fix update storage logic to take into account config file

### DIFF
--- a/charts/tezos/scripts/upgrade-storage.sh
+++ b/charts/tezos/scripts/upgrade-storage.sh
@@ -5,4 +5,4 @@ then
   printf "No context in data dir found, probably initial start, doing nothing."
   exit 0
 fi
-octez-node upgrade storage --data-dir /var/tezos/node/data
+octez-node upgrade storage --config /etc/tezos/config.json

--- a/test/charts/mainnet.expect.yaml
+++ b/test/charts/mainnet.expect.yaml
@@ -389,7 +389,7 @@ spec:
                 printf "No context in data dir found, probably initial start, doing nothing."
                 exit 0
               fi
-              octez-node upgrade storage --data-dir /var/tezos/node/data
+              octez-node upgrade storage --config /etc/tezos/config.json
               
           envFrom:
           env:

--- a/test/charts/mainnet2.expect.yaml
+++ b/test/charts/mainnet2.expect.yaml
@@ -500,7 +500,7 @@ spec:
                 printf "No context in data dir found, probably initial start, doing nothing."
                 exit 0
               fi
-              octez-node upgrade storage --data-dir /var/tezos/node/data
+              octez-node upgrade storage --config /etc/tezos/config.json
               
           envFrom:
           env:
@@ -870,7 +870,7 @@ spec:
                 printf "No context in data dir found, probably initial start, doing nothing."
                 exit 0
               fi
-              octez-node upgrade storage --data-dir /var/tezos/node/data
+              octez-node upgrade storage --config /etc/tezos/config.json
               
           envFrom:
           env:

--- a/test/charts/private-chain.expect.yaml
+++ b/test/charts/private-chain.expect.yaml
@@ -446,7 +446,7 @@ spec:
                 printf "No context in data dir found, probably initial start, doing nothing."
                 exit 0
               fi
-              octez-node upgrade storage --data-dir /var/tezos/node/data
+              octez-node upgrade storage --config /etc/tezos/config.json
               
           envFrom:
           env:
@@ -1014,7 +1014,7 @@ spec:
                 printf "No context in data dir found, probably initial start, doing nothing."
                 exit 0
               fi
-              octez-node upgrade storage --data-dir /var/tezos/node/data
+              octez-node upgrade storage --config /etc/tezos/config.json
               
           envFrom:
           env:
@@ -1218,7 +1218,7 @@ spec:
                 printf "No context in data dir found, probably initial start, doing nothing."
                 exit 0
               fi
-              octez-node upgrade storage --data-dir /var/tezos/node/data
+              octez-node upgrade storage --config /etc/tezos/config.json
               
           envFrom:
           env:


### PR DESCRIPTION
With v15 to v16 upgrades, we started seeing failures updating storage of non-mainnet networks.

We reported upstream:

https://gitlab.com/tezos/tezos/-/issues/4892#note_1287844009

However it turns out that the data dir we were passing did not have a config file, so it was unable to figure out which network the data dir was for.

This is fixed by passing config file instead of data dir.

I tried by launching v15 ghostnet from a snapshot, then upgrading to v16. I also tried launching a v16 tarball directly from scratch. Both worked.

test