### PR TITLE
snapshotEngine: pvc for rolling snapshot increase to 20Gigs

### DIFF
--- a/snapshotEngine/scratchVolume.yaml
+++ b/snapshotEngine/scratchVolume.yaml
@@ -9,4 +9,4 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 10Gi
+      storage: 20Gi


### PR DESCRIPTION
The mainnet rolling tezos snapshot grew significantly from v15 to v16 and so we need to increase the size of the PVC we write the snapshot to.