### PR TITLE
rename tezos-baker to octez-baker

### DIFF
--- a/charts/tezos/scripts/baker.sh
+++ b/charts/tezos/scripts/baker.sh
@@ -33,7 +33,7 @@ if [ "${my_baker_account}" == "" ]; then
 fi
 
 CLIENT="$TEZ_BIN/octez-client -d $CLIENT_DIR"
-CMD="$TEZ_BIN/tezos-baker-$proto_command -d $CLIENT_DIR"
+CMD="$TEZ_BIN/octez-baker-$proto_command -d $CLIENT_DIR"
 
 # ensure we can run octez-client commands without specifying client dir
 ln -s /var/tezos/client /home/tezos/.tezos-client

--- a/charts/tezos/scripts/remote-signer.sh
+++ b/charts/tezos/scripts/remote-signer.sh
@@ -6,7 +6,7 @@ CLIENT_DIR="$TEZ_VAR/client"
 NODE_DIR="$TEZ_VAR/node"
 NODE_DATA_DIR="$TEZ_VAR/node/data"
 
-CMD="$TEZ_BIN/tezos-signer -d $CLIENT_DIR launch http signer --magic-bytes 0x11,0x12,0x13 --check-high-watermark -a 0.0.0.0 -p 6732"
+CMD="$TEZ_BIN/octez-signer -d $CLIENT_DIR launch http signer --magic-bytes 0x11,0x12,0x13 --check-high-watermark -a 0.0.0.0 -p 6732"
 
 # ensure we can run tezos-signer commands without specifying client dir
 ln -s /var/tezos/client /home/tezos/.tezos-signer

--- a/charts/tezos/templates/_containers.tpl
+++ b/charts/tezos/templates/_containers.tpl
@@ -324,7 +324,7 @@
   image: "{{ or $node_vals_images.octez $.Values.images.octez }}"
   imagePullPolicy: IfNotPresent
   command:
-    - /usr/local/bin/tezos-baker-{{ .command }}
+    - /usr/local/bin/octez-baker-{{ .command }}
   args:
     - run
     - vdf

--- a/test/charts/private-chain.expect.yaml
+++ b/test/charts/private-chain.expect.yaml
@@ -1295,7 +1295,7 @@ spec:
             NODE_DIR="$TEZ_VAR/node"
             NODE_DATA_DIR="$TEZ_VAR/node/data"
             
-            CMD="$TEZ_BIN/tezos-signer -d $CLIENT_DIR launch http signer --magic-bytes 0x11,0x12,0x13 --check-high-watermark -a 0.0.0.0 -p 6732"
+            CMD="$TEZ_BIN/octez-signer -d $CLIENT_DIR launch http signer --magic-bytes 0x11,0x12,0x13 --check-high-watermark -a 0.0.0.0 -p 6732"
             
             # ensure we can run tezos-signer commands without specifying client dir
             ln -s /var/tezos/client /home/tezos/.tezos-signer

--- a/test/charts/private-chain.expect.yaml
+++ b/test/charts/private-chain.expect.yaml
@@ -599,7 +599,7 @@ spec:
               fi
               
               CLIENT="$TEZ_BIN/octez-client -d $CLIENT_DIR"
-              CMD="$TEZ_BIN/tezos-baker-$proto_command -d $CLIENT_DIR"
+              CMD="$TEZ_BIN/octez-baker-$proto_command -d $CLIENT_DIR"
               
               # ensure we can run octez-client commands without specifying client dir
               ln -s /var/tezos/client /home/tezos/.tezos-client
@@ -666,7 +666,7 @@ spec:
               fi
               
               CLIENT="$TEZ_BIN/octez-client -d $CLIENT_DIR"
-              CMD="$TEZ_BIN/tezos-baker-$proto_command -d $CLIENT_DIR"
+              CMD="$TEZ_BIN/octez-baker-$proto_command -d $CLIENT_DIR"
               
               # ensure we can run octez-client commands without specifying client dir
               ln -s /var/tezos/client /home/tezos/.tezos-client
@@ -733,7 +733,7 @@ spec:
               fi
               
               CLIENT="$TEZ_BIN/octez-client -d $CLIENT_DIR"
-              CMD="$TEZ_BIN/tezos-baker-$proto_command -d $CLIENT_DIR"
+              CMD="$TEZ_BIN/octez-baker-$proto_command -d $CLIENT_DIR"
               
               # ensure we can run octez-client commands without specifying client dir
               ln -s /var/tezos/client /home/tezos/.tezos-client
@@ -800,7 +800,7 @@ spec:
               fi
               
               CLIENT="$TEZ_BIN/octez-client -d $CLIENT_DIR"
-              CMD="$TEZ_BIN/tezos-baker-$proto_command -d $CLIENT_DIR"
+              CMD="$TEZ_BIN/octez-baker-$proto_command -d $CLIENT_DIR"
               
               # ensure we can run octez-client commands without specifying client dir
               ln -s /var/tezos/client /home/tezos/.tezos-client
@@ -867,7 +867,7 @@ spec:
               fi
               
               CLIENT="$TEZ_BIN/octez-client -d $CLIENT_DIR"
-              CMD="$TEZ_BIN/tezos-baker-$proto_command -d $CLIENT_DIR"
+              CMD="$TEZ_BIN/octez-baker-$proto_command -d $CLIENT_DIR"
               
               # ensure we can run octez-client commands without specifying client dir
               ln -s /var/tezos/client /home/tezos/.tezos-client


### PR DESCRIPTION
now that v14 is no longer relevant we can finish renaming. The current terminology will probably be deprecated in v17.