### PR TITLE
fix tezos pod crash when config already exists

### DIFF
--- a/charts/tezos/scripts/config-init.sh
+++ b/charts/tezos/scripts/config-init.sh
@@ -5,9 +5,9 @@ mkdir -p /etc/tezos/data
 
 # if config already exists (container is rebooting), dump and delete it.
 if [ -e /etc/tezos/data/config.json ]; then
-  printf("Found pre-existing config.json:\r")
+  printf "Found pre-existing config.json:\n"
   cat /etc/tezos/data/config.json
-  printf("Deleting")
+  printf "Deleting\n"
   rm -rvf /etc/tezos/data/config.json
 fi
 

--- a/charts/tezos/scripts/config-init.sh
+++ b/charts/tezos/scripts/config-init.sh
@@ -3,6 +3,14 @@ set -e
 echo "Writing custom configuration for public node"
 mkdir -p /etc/tezos/data
 
+# if config already exists (container is rebooting), dump and delete it.
+if [ -e /etc/tezos/data/config.json ]; then
+  printf("Found pre-existing config.json:\r")
+  cat /etc/tezos/data/config.json
+  printf("Deleting")
+  rm -rvf /etc/tezos/data/config.json
+fi
+
 /usr/local/bin/octez-node config init		\
     --config-file /etc/tezos/data/config.json	\
     --data-dir /etc/tezos/data			\

--- a/test/charts/mainnet.expect.yaml
+++ b/test/charts/mainnet.expect.yaml
@@ -221,6 +221,14 @@ spec:
               echo "Writing custom configuration for public node"
               mkdir -p /etc/tezos/data
               
+              # if config already exists (container is rebooting), dump and delete it.
+              if [ -e /etc/tezos/data/config.json ]; then
+                printf "Found pre-existing config.json:\n"
+                cat /etc/tezos/data/config.json
+                printf "Deleting\n"
+                rm -rvf /etc/tezos/data/config.json
+              fi
+              
               /usr/local/bin/octez-node config init		\
                   --config-file /etc/tezos/data/config.json	\
                   --data-dir /etc/tezos/data			\

--- a/test/charts/mainnet2.expect.yaml
+++ b/test/charts/mainnet2.expect.yaml
@@ -324,6 +324,14 @@ spec:
               echo "Writing custom configuration for public node"
               mkdir -p /etc/tezos/data
               
+              # if config already exists (container is rebooting), dump and delete it.
+              if [ -e /etc/tezos/data/config.json ]; then
+                printf "Found pre-existing config.json:\n"
+                cat /etc/tezos/data/config.json
+                printf "Deleting\n"
+                rm -rvf /etc/tezos/data/config.json
+              fi
+              
               /usr/local/bin/octez-node config init		\
                   --config-file /etc/tezos/data/config.json	\
                   --data-dir /etc/tezos/data			\
@@ -693,6 +701,14 @@ spec:
               
               echo "Writing custom configuration for public node"
               mkdir -p /etc/tezos/data
+              
+              # if config already exists (container is rebooting), dump and delete it.
+              if [ -e /etc/tezos/data/config.json ]; then
+                printf "Found pre-existing config.json:\n"
+                cat /etc/tezos/data/config.json
+                printf "Deleting\n"
+                rm -rvf /etc/tezos/data/config.json
+              fi
               
               /usr/local/bin/octez-node config init		\
                   --config-file /etc/tezos/data/config.json	\


### PR DESCRIPTION
Today I found a baking node in this state: the init container was in a failure loop. `config-init` had the following message:

```
Writing custom configuration for public node

octez-node: Error:

              Pre-existing configuration file at
/etc/tezos/data/config.json, use `reset`.
```

Addressing this by ensuring config-init always works, despite pre-existing data. This does not solve the root cause (unknown) but ensures that the tezos pod starts in this scenario.

This is not usual; config-volume is an emptydir so when the pod restart, it should be empty. It could be that this specific cloud provider does not clear the config dir upon pod reboot, or the init-containers re-run in the pod when config-volume is not empty.