### PR TITLE
snapshotEngine: Proper schema validation

### DIFF
--- a/snapshotEngine/getAllSnapshotMetadata.py
+++ b/snapshotEngine/getAllSnapshotMetadata.py
@@ -48,7 +48,7 @@ with open("schema.json","r") as f:
     schema = f.read()
 
 # json.validate() returns None if successful
-if not validate(metadata_document, json.loads(schema)):
+if not validate(json.loads(metadata_document), json.loads(schema)):
     print("Metadata sucessfully validated against schema!")
 else:
     raise Exception("Metadata NOT validated against schema!")

--- a/snapshotEngine/getAllSnapshotMetadata.py
+++ b/snapshotEngine/getAllSnapshotMetadata.py
@@ -49,7 +49,7 @@ with open("schema.json","r") as f:
 
 # json.validate() returns None if successful
 if not validate(json.loads(metadata_document), json.loads(schema)):
-    print("Metadata sucessfully validated against schema!")
+    print("Metadata successfully validated against schema!")
 else:
     raise Exception("Metadata NOT validated against schema!")
 


### PR DESCRIPTION
We found that the schema file was not working due to nesting problems. It was updated in the schema repo, but then the Python validation did not like the object that was passed to it. This was fixed by switching to `json.loads` instead of feeding in a string to the validation library.

Merge this PR then this https://github.com/oxheadalpha/tezos-snapshot-metadata-schema/pull/5