### PR TITLE
Add timeout for /is_synced endpoint in sidecar.py

### DIFF
--- a/utils/sidecar.py
+++ b/utils/sidecar.py
@@ -12,7 +12,7 @@ log.setLevel(logging.ERROR)
 application = Flask(__name__)
 
 AGE_LIMIT_IN_SECS = 600
-# Default readiness probeperid timeout is 1s, timeout sync request before that and return a
+# Default readiness probe periodSeconds is 1s, timeout sync request before that and return a
 # connect timeout error if necessary
 NODE_CONNECT_TIMEOUT = 0.9
 

--- a/utils/sidecar.py
+++ b/utils/sidecar.py
@@ -12,7 +12,8 @@ log.setLevel(logging.ERROR)
 application = Flask(__name__)
 
 AGE_LIMIT_IN_SECS = 600
-# Default readiness probe periodSeconds is 1s, timeout sync request before that and return a
+# https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+# Default readiness probe timeoutSeconds is 1s, timeout sync request before that and return a
 # connect timeout error if necessary
 NODE_CONNECT_TIMEOUT = 0.9
 

--- a/utils/sidecar.py
+++ b/utils/sidecar.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 from flask import Flask, escape, request
 import requests
-from requests.exceptions import ConnectTimeout, RequestException
+from requests.exceptions import ConnectTimeout, ReadTimeout, RequestException
 import datetime
 
 import logging
@@ -29,6 +29,10 @@ def sync_checker():
         r = requests.get("http://127.0.0.1:8732/chains/main/blocks/head/header", timeout=NODE_CONNECT_TIMEOUT)
     except ConnectTimeout as e:
         err = "Timeout connect to node, %s" % repr(e), 500
+        application.logger.error(err)
+        return err
+    except ReadTimeout as e:
+        err = "Timeout read from node, %s" % repr(e), 500
         application.logger.error(err)
         return err
     except RequestException as e:

--- a/utils/sidecar.py
+++ b/utils/sidecar.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-from flask import Flask, escape, request
+from flask import Flask
 import requests
 from requests.exceptions import ConnectTimeout, ReadTimeout, RequestException
 import datetime


### PR DESCRIPTION
In out prod environment we could observe that requests piling up as there is no timeout in default requests get method. Here we timeout and close the connection timely to avoid the piling up.

This is an alternative way to fix the issue mentioned here https://github.com/oxheadalpha/tezos-k8s/pull/562