### PR TITLE
Enable arm64 builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,6 +190,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
+          provenance: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           file: ${{ matrix.container }}/Dockerfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,7 +184,7 @@ jobs:
             type=match,pattern=([0-9]+\.[0-9]+\.[0-9]+),group=1
 
       - name: Push ${{ matrix.container }} container to GHCR
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v2
         with:
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,7 +184,7 @@ jobs:
             type=match,pattern=([0-9]+\.[0-9]+\.[0-9]+),group=1
 
       - name: Push ${{ matrix.container }} container to GHCR
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,7 @@ jobs:
             type=match,pattern=([0-9]+\.[0-9]+\.[0-9]+),group=1
 
       - name: Push ${{ matrix.container }} container to GHCR
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           push: true
           provenance: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,9 @@ jobs:
         with:
           install: true
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
       - name: Login to registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,6 +191,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           file: ${{ matrix.container }}/Dockerfile
           context: ${{ matrix.container}}/.
+          platforms: linux/amd64,linux/arm64
 
           # Cache settings
           builder: ${{ steps.buildx.outputs.name }}

--- a/snapshotEngine/Dockerfile
+++ b/snapshotEngine/Dockerfile
@@ -6,8 +6,7 @@ ENV GLIBC_VER=2.31-r0
 ENV PYTHONUNBUFFERED=1
 ENV KUBECTL_VERSION=v1.24.3
 
-ARG TARGETPLATFORM
-ARG ARCH=$(echo ${TARGETPLATFORM} | sed 's:.*/::')
+ARG TARGETARCH
 
 #
 # Installs lz4, jq, yq, kubectl, and awscliv2, and python3
@@ -18,10 +17,11 @@ RUN apk --no-cache add \
         lz4 \
         'jq<1.6-r1'  \
         bash \
+    && echo "Arch: ${TARGETARCH}" \
     && wget -q -O /usr/bin/yq $(wget -q -O - https://api.github.com/repos/mikefarah/yq/releases/latest \
-        | jq -r '.assets[] | select(.name == "yq_linux_${ARCH}") | .browser_download_url') \
+        | jq -r --arg YQ_ARCH "yq_linux_${TARGETARCH}" '.assets[] | select(.name == $YQ_ARCH) | .browser_download_url') \
     && chmod +x /usr/bin/yq \
-    && curl -LO https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl \
+    && curl -LO https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl \
     && chmod +x ./kubectl \
     && mv ./kubectl /usr/local/bin \
     && curl -sL https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \

--- a/snapshotEngine/Dockerfile
+++ b/snapshotEngine/Dockerfile
@@ -6,6 +6,9 @@ ENV GLIBC_VER=2.31-r0
 ENV PYTHONUNBUFFERED=1
 ENV KUBECTL_VERSION=v1.24.3
 
+ARG TARGETPLATFORM
+ARG ARCH=$(echo ${TARGETPLATFORM} | sed 's:.*/::')
+
 #
 # Installs lz4, jq, yq, kubectl, and awscliv2, and python3
 #
@@ -16,9 +19,9 @@ RUN apk --no-cache add \
         'jq<1.6-r1'  \
         bash \
     && wget -q -O /usr/bin/yq $(wget -q -O - https://api.github.com/repos/mikefarah/yq/releases/latest \
-        | jq -r '.assets[] | select(.name == "yq_linux_amd64") | .browser_download_url') \
+        | jq -r '.assets[] | select(.name == "yq_linux_${ARCH}") | .browser_download_url') \
     && chmod +x /usr/bin/yq \
-    && curl -LO https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl \
+    && curl -LO https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl \
     && chmod +x ./kubectl \
     && mv ./kubectl /usr/local/bin \
     && curl -sL https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \


### PR DESCRIPTION
Adds builds for arm64

Luckily snapshotEngine was the only image that had a problem and I am using TARGETARCH to grab architecture-specific kubectl and yq binaries.

Had to add a setup-qemu step as well.