### PR TITLE
Add Node RPC and BCD ingresses

### DIFF
--- a/charts/tezos/templates/_helpers.tpl
+++ b/charts/tezos/templates/_helpers.tpl
@@ -133,7 +133,7 @@ metadata:
   Returns the true type or empty string which is falsey.
 */}}
 {{- define "tezos.shouldDeployBcdIndexer" -}}
-  {{- if and .indexerRpcUrl .db.password }}
+  {{- if and .rpcUrl .db.password }}
     {{- "true" }}
   {{- else }}
     {{- "" }}

--- a/charts/tezos/templates/bcd_indexer.yaml
+++ b/charts/tezos/templates/bcd_indexer.yaml
@@ -176,7 +176,7 @@ spec:
               mountPath: /app/indexer/sandbox.yml
               subPath: sandbox.yml
       {{- if $indexerConfig.gui.enabled }}
-        {{- $_ := required "gui.apiUrl is required" $indexerConfig.gui.apiUrl }}
+        {{- $_ := required "apiUrl is required" $indexerConfig.apiUrl }}
         {{- $_ := required "gui.rpcUrl is required" $indexerConfig.gui.rpcUrl }}
         - image: {{ $indexerConfig.images.gui }}
           name: gui
@@ -189,7 +189,7 @@ spec:
             - |
               set -ex
 
-              api_url="{{ $indexerConfig.gui.apiUrl }}/v1"
+              api_url="{{ $indexerConfig.apiUrl }}/v1"
 
               for file in js/*; do
                 echo $file
@@ -221,6 +221,58 @@ spec:
         resources:
           requests:
             storage: {{ $indexerConfig.storage | default "300Gi" }}
+{{- end }}
+
+---
+{{- if $indexerConfig.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: bcd
+  namespace: {{ .Release.Namespace }}
+{{- with $indexerConfig.ingress.labels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
+{{- with $indexerConfig.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
+spec:
+  ingressClassName: {{ $indexerConfig.ingress.className | default "" }}
+  {{- if $indexerConfig.ingress.tls }}
+  tls:
+    {{- range $indexerConfig.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    - host: {{ regexReplaceAll "(https?://)" $indexerConfig.apiUrl "" }}
+      http:
+        paths:
+          - pathType: Prefix
+            path: /
+            backend:
+              service:
+                name: bcd
+                port:
+                  number: 14000
+  {{- if and $indexerConfig.gui.enabled $indexerConfig.ingress.guiHostname }}
+    - host: {{ $indexerConfig.ingress.guiHostname }}
+      http:
+        paths:
+          - pathType: Prefix
+            path: /
+            backend:
+              service:
+                name: bcd
+                port:
+                  number: 8080
+    {{- end }}
 {{- end }}
 
 {{- end }}

--- a/charts/tezos/templates/bcd_indexer.yaml
+++ b/charts/tezos/templates/bcd_indexer.yaml
@@ -29,7 +29,7 @@ metadata:
 data:
   BCD_ENV: sandbox
   GIN_MODE: debug
-  SANDBOX_NODE_URI: {{ $indexerConfig.indexerRpcUrl }}
+  SANDBOX_NODE_URI: {{ $indexerConfig.rpcUrl }}
 
 ---
 apiVersion: v1
@@ -176,8 +176,8 @@ spec:
               mountPath: /app/indexer/sandbox.yml
               subPath: sandbox.yml
       {{- if $indexerConfig.gui.enabled }}
-        {{- $_ := required "apiUrl is required" $indexerConfig.apiUrl }}
-        {{- $_ := required "gui.rpcUrl is required" $indexerConfig.gui.rpcUrl }}
+        {{- $_ := required "apiUrl is required for gui" $indexerConfig.apiUrl }}
+        {{- $_ := required "gui.rpcUrl is required for gui" $indexerConfig.gui.rpcUrl }}
         - image: {{ $indexerConfig.images.gui }}
           name: gui
           ports:
@@ -225,6 +225,7 @@ spec:
 
 ---
 {{- if $indexerConfig.ingress.enabled }}
+{{- $_ := required "apiUrl is required for ingress" $indexerConfig.apiUrl }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -254,7 +255,7 @@ spec:
     - host: {{ regexReplaceAll "(https?://)" $indexerConfig.apiUrl "" }}
       http:
         paths:
-          - pathType: Prefix
+          - pathType: {{ $indexerConfig.ingress.pathType }}
             path: /
             backend:
               service:
@@ -265,7 +266,7 @@ spec:
     - host: {{ $indexerConfig.ingress.guiHostname }}
       http:
         paths:
-          - pathType: Prefix
+          - pathType: {{ $indexerConfig.ingress.pathType }}
             path: /
             backend:
               service:

--- a/charts/tezos/templates/bcd_indexer.yaml
+++ b/charts/tezos/templates/bcd_indexer.yaml
@@ -240,7 +240,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
 {{- end }}
 spec:
-  ingressClassName: {{ $indexerConfig.ingress.className | default "" }}
+  ingressClassName: {{ $indexerConfig.ingress.className }}
   {{- if $indexerConfig.ingress.tls }}
   tls:
     {{- range $indexerConfig.ingress.tls }}

--- a/charts/tezos/templates/ingress.yaml
+++ b/charts/tezos/templates/ingress.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.ingress.enabled }}
+{{- $_ := required "host is required for tezos-node-rpc ingress" .Values.ingress.host }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: tezos-node-rpc
+  namespace: {{ .Release.Namespace }}
+{{- with .Values.ingress.labels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
+{{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
+spec:
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host }}
+      http:
+        paths:
+          - pathType: {{ .Values.ingress.pathType }}
+            path: /
+            backend:
+              service:
+                name: tezos-node-rpc
+                port:
+                  number: 8732
+{{- end }}

--- a/charts/tezos/values.yaml
+++ b/charts/tezos/values.yaml
@@ -269,6 +269,16 @@ services:
     selector:
 #      rpc_node: "true"
 
+## Configuration for the tezos-node-rpc ingress
+ingress:
+  enabled: false
+  host: ""
+  annotations: {}
+  className: ""
+  labels: {}
+  pathType: Prefix
+  tls: []
+
 # Prometheus Operator is required in your cluster in order to enable
 # serviceMonitor below.
 # ServiceMonitor allows you to scrape the prometheus endpoints of your tezos nodes.
@@ -569,7 +579,7 @@ bcdIndexer:
     annotations: {}
     className: ""
     labels: {}
-    pathType: ImplementationSpecific
+    pathType: Prefix
     tls: []
 
   db:

--- a/charts/tezos/values.yaml
+++ b/charts/tezos/values.yaml
@@ -549,15 +549,27 @@ bcdIndexer:
     gui: ghcr.io/baking-bad/bcdhub-gui:4.4.0
     postgres: postgres:14
 
+  # Url of the RPC backend for the indexer to hit
+  indexerRpcUrl: "" # http://archive-baking-node-0.archive-baking-node:8732
+  # When creating an ingress, this will be the BCD api's hostname/FQDN (stripped
+  # of http(s)). When deploying the BCD gui, this will also be the api's full
+  # url called by the frontend.
+  apiUrl: "" # http://localhost:14000
+
   gui:
     enabled: false
-    ## Url of the BCD api for the frontend to hit
-    apiUrl: http://localhost:14000
-    ## Url to the RPC backend for the frontend to hit
+    # Url of the RPC backend for the frontend to query
     rpcUrl: http://localhost:8732
 
-  ## RPC url of the node to be indexed
-  # indexerRpcUrl: http://archive-baking-node-0.archive-baking-node:8732
+  ingress:
+    enabled: false
+    # Hostname for BCD frontend. The ingress rule will only be created when this
+    # is set and gui is enabled.
+    guiHostname: ""
+    annotations: {}
+    className: ""
+    labels: {}
+    tls: []
 
   db:
     # By default creates a postgres db container. Setting to true won't create

--- a/charts/tezos/values.yaml
+++ b/charts/tezos/values.yaml
@@ -549,8 +549,8 @@ bcdIndexer:
     gui: ghcr.io/baking-bad/bcdhub-gui:4.4.0
     postgres: postgres:14
 
-  # Url of the RPC backend for the indexer to hit
-  indexerRpcUrl: "" # http://archive-baking-node-0.archive-baking-node:8732
+  # Url of the RPC backend for the indexer to index
+  rpcUrl: "" # http://archive-baking-node-0.archive-baking-node:8732
   # When creating an ingress, this will be the BCD api's hostname/FQDN (stripped
   # of http(s)). When deploying the BCD gui, this will also be the api's full
   # url called by the frontend.
@@ -569,6 +569,7 @@ bcdIndexer:
     annotations: {}
     className: ""
     labels: {}
+    pathType: ImplementationSpecific
     tls: []
 
   db:


### PR DESCRIPTION
Adds ability to deploy ingresses for the node rpc endpoint as well as for the BCD ui and api.

I put bcd ing in the bcd_indexer.yaml file. It's all the resources in one file. When we move bcd into it's own chart we will split the resources into different files.

I created a new ingress.yaml file for the rpc ing.