### PR TITLE
Octez: increase request to 700Mi and limit to 1Gi

### DIFF
--- a/charts/tezos/templates/_containers.tpl
+++ b/charts/tezos/templates/_containers.tpl
@@ -254,7 +254,7 @@
 
 {{- define "tezos.container.sidecar" }}
   {{- if or (not (hasKey $.node_vals "readiness_probe")) $.node_vals.readiness_probe }}
-    {{- $sidecarResources := dict "requests" (dict "memory" "80Mi") "limits" (dict "memory" "100Mi") -}}
+    {{- $sidecarResources := dict "requests" (dict "memory" "700Mi") "limits" (dict "memory" "1Gi") -}}
     {{- include "tezos.generic_container" (dict "root"      $
                                                 "type"      "sidecar"
                                                 "image"     "utils"

--- a/test/charts/mainnet.expect.yaml
+++ b/test/charts/mainnet.expect.yaml
@@ -207,9 +207,9 @@ spec:
               name: var-volume
           resources:
             limits:
-              memory: 100Mi
+              memory: 1Gi
             requests:
-              memory: 80Mi        
+              memory: 700Mi        
       initContainers:        
         - name: config-init
           image: "tezos/tezos:v16.1"

--- a/test/charts/mainnet2.expect.yaml
+++ b/test/charts/mainnet2.expect.yaml
@@ -310,9 +310,9 @@ spec:
               name: var-volume
           resources:
             limits:
-              memory: 100Mi
+              memory: 1Gi
             requests:
-              memory: 80Mi        
+              memory: 700Mi        
       initContainers:        
         - name: config-init
           image: "tezos/tezos:v16.1"
@@ -688,9 +688,9 @@ spec:
               name: var-volume
           resources:
             limits:
-              memory: 100Mi
+              memory: 1Gi
             requests:
-              memory: 80Mi        
+              memory: 700Mi        
       initContainers:        
         - name: config-init
           image: "tezos/tezos:v15-release"

--- a/test/charts/private-chain.expect.yaml
+++ b/test/charts/private-chain.expect.yaml
@@ -603,9 +603,9 @@ spec:
               name: var-volume
           resources:
             limits:
-              memory: 100Mi
+              memory: 1Gi
             requests:
-              memory: 80Mi        
+              memory: 700Mi        
       initContainers:                        
         - name: config-generator
           image: "ghcr.io/oxheadalpha/tezos-k8s-utils:master"
@@ -1176,9 +1176,9 @@ spec:
               name: var-volume
           resources:
             limits:
-              memory: 100Mi
+              memory: 1Gi
             requests:
-              memory: 80Mi        
+              memory: 700Mi        
       initContainers:                        
         - name: config-generator
           image: "ghcr.io/oxheadalpha/tezos-k8s-utils:master"
@@ -1380,9 +1380,9 @@ spec:
               name: var-volume
           resources:
             limits:
-              memory: 100Mi
+              memory: 1Gi
             requests:
-              memory: 80Mi        
+              memory: 700Mi        
       initContainers:                        
         - name: config-generator
           image: "ghcr.io/oxheadalpha/tezos-k8s-utils:master"


### PR DESCRIPTION
A tezos node runs anywhere between 600MB and 700MB of RAM.  

By having the `request` so low (Currently set at 100Mi) it prevents the pod from being scheduled accurately to a node.  I discovered this while downscaling oxheadinfra. 

What happens is the schedule controller only sees the 100Mi request, and goes "Ok node you can handle 40 of these or more", but then since its actually 6x that the node OOMs and can't run the pods until a sizable node is made available.  

Now with a proper request pods wont be scheduled to a node that cant actually handle it.