### PR TITLE
add persistent volume for pyrometer

### DIFF
--- a/charts/pyrometer/templates/deployment.yaml
+++ b/charts/pyrometer/templates/deployment.yaml
@@ -16,6 +16,8 @@ spec:
         # https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
+      securityContext:
+        fsGroup: 1000
       containers:
       - name: pyrometer
         image: {{ .Values.images.pyrometer }}
@@ -23,6 +25,8 @@ spec:
         - run
         - -c
         - '/config/config.json'
+        - -d
+        - '/data'
         ports:
           - name: http
             containerPort: 80
@@ -30,6 +34,8 @@ spec:
         volumeMounts:
         - name: config-volume
           mountPath: /config/
+        - name: pyrometer-volume
+          mountPath: /data/
       - name: prom-exporter
         image: {{ .Values.tezos_k8s_images.utils }}
         ports:
@@ -46,3 +52,7 @@ spec:
       - name: config-volume
         configMap:
           name: pyrometer-config
+      - name: pyrometer-volume
+        # Stores pyrometer's state (like pending queue items)
+        persistentVolumeClaim:
+          claimName: pyrometer-volume

--- a/charts/pyrometer/templates/volume.yaml
+++ b/charts/pyrometer/templates/volume.yaml
@@ -2,6 +2,7 @@ apiVersion: "v1"
 kind: PersistentVolumeClaim
 metadata:
   name: pyrometer-volume
+  namespace: {{ .Release.Namespace }}
 spec:
  storageClassName:
  accessModes:

--- a/charts/pyrometer/templates/volume.yaml
+++ b/charts/pyrometer/templates/volume.yaml
@@ -1,0 +1,11 @@
+apiVersion: "v1"
+kind: PersistentVolumeClaim
+metadata:
+  name: pyrometer-volume
+spec:
+ storageClassName:
+ accessModes:
+    - ReadWriteOnce
+ resources:
+   requests:
+     storage: 1Gi


### PR DESCRIPTION
Pyrometer saves its message queue on disk. Upon restart, we ensure that
the messages in the queue will be processed.