### PR TITLE
switch pyrometer to port 8080

### DIFF
--- a/charts/pyrometer/templates/deployment.yaml
+++ b/charts/pyrometer/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
         - '/data'
         ports:
           - name: http
-            containerPort: 80
+            containerPort: 8080
             protocol: TCP
         volumeMounts:
         - name: config-volume

--- a/charts/pyrometer/templates/ingress.yaml
+++ b/charts/pyrometer/templates/ingress.yaml
@@ -45,5 +45,5 @@ spec:
               service:
                 name: "pyrometer"
                 port:
-                  number: 80
+                  number: 8080
 {{- end }}

--- a/charts/pyrometer/templates/service.yaml
+++ b/charts/pyrometer/templates/service.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   type: NodePort
   ports:
-    - port: 80
+    - port: 8080
       targetPort: http
       protocol: TCP
       name: http

--- a/charts/pyrometer/values.yaml
+++ b/charts/pyrometer/values.yaml
@@ -8,7 +8,7 @@ config:
     nodes:
     - http://tezos-node-rpc:8732
   ui:
-    enabled: true
+    enabled: false
     host: "0.0.0.0"
     port: 8080
   webhook:

--- a/charts/pyrometer/values.yaml
+++ b/charts/pyrometer/values.yaml
@@ -7,6 +7,10 @@ config:
   node_monitor:
     nodes:
     - http://tezos-node-rpc:8732
+  ui:
+    enabled: true
+    host: "0.0.0.0"
+    port: 8080
   webhook:
     enabled: true
     url: http://127.0.0.1:31732/pyrometer_webhook


### PR DESCRIPTION
fix after teztnets breakage. there is no pyrometer twin PR as the port is configurable purely from config.json without a docker change.