### PR TITLE
Tezos-k8s nairobi release

### DIFF
--- a/charts/snapshotEngine/values.yaml
+++ b/charts/snapshotEngine/values.yaml
@@ -3,7 +3,7 @@ tezos_k8s_images:
 
 # the tezos version used to run `octez-node snapshot import/export`
 images:
-  octez: tezos/tezos:v16.1
+  octez: tezos/tezos:v17.1
 
 # snapshotEngine containers interact with the kubernetes control
 # plane to create volume snapshots. This requires a special IAM role

--- a/charts/tezos/values.yaml
+++ b/charts/tezos/values.yaml
@@ -416,7 +416,7 @@ protocols:
 ## after chain activation.
 ##
 # activation:
-#  protocol_hash: PtMumbai2TmsJHNGRkD8v8YDbtao7BLUC3wjASn1inAKLFCjaH1
+#  protocol_hash: PtNairobiyssHuh87hEhfVBGCVrK3WnS8Z2FT4ymB5tAa4r1nQf
 #  protocol_parameters:
 #    preserved_cycles: 3
 #    blocks_per_cycle: 8
@@ -478,10 +478,11 @@ protocols:
 #      number_of_slots: 256
 #      number_of_shards: 2048
 #      attestation_lag: 2
-#      availability_threshold: 50
+#      attestation_threshold: 50
 #      slot_size: 1048576
 #      redundancy_factor: 16
 #      page_size: 4096
+#      blocks_per_epoch: 8
 #    smart_rollup_enable: true
 #    smart_rollup_origination_size: 6314
 #    smart_rollup_challenge_window_in_blocks: 40

--- a/charts/tezos/values.yaml
+++ b/charts/tezos/values.yaml
@@ -8,7 +8,7 @@ is_invitation: false
 
 # Images not part of the tezos-k8s repo go here
 images:
-  octez: tezos/tezos:v16.1
+  octez: tezos/tezos:v17.1
   tacoinfraRemoteSigner: ghcr.io/oxheadalpha/tacoinfra-remote-signer:0.1.0
 # Images that are part of the tezos-k8s repo go here with 'dev' tag
 tezos_k8s_images:
@@ -404,7 +404,7 @@ protocols:
   ##   "on" and "off" must be between quotes.
   ## Note that we are not providing default votes since every baker needs
   ## to make an explicit educated choice on every toggle.
-  - command: PtMumbai
+  - command: PtNairob
     vote: {}
   # - command: alpha
   #   vote:

--- a/mkchain/README.md
+++ b/mkchain/README.md
@@ -86,7 +86,7 @@ You can explicitly specify some values by:
 |                                  | --number-of-nodes        | Number of non-baking nodes in the cluster                      | 0                       |
 | bootstrap_peers                  | --bootstrap-peers        | Peer ips to connect to                                         | []                      |
 | expected_proof_of_work           | --expected-proof-of-work | Node identity generation difficulty                            | 0                       |
-| images.octez                     | --octez-docker-image     | Version of the Octez docker image to run                       | tezos/tezos:v16.1 |
+| images.octez                     | --octez-docker-image     | Version of the Octez docker image to run                       | tezos/tezos:v17.1 |
 |                                  | --use-docker (--no...)   | Use (or don't use) docker to generate keys rather than pytezos | autodetect              |
 | zerotier_config.zerotier_network | --zerotier-network       | Zerotier network id for external chain access                  |                         |
 | zerotier_config.zerotier_token   | --zerotier-token         | Zerotier token for external chain access                       |                         |

--- a/mkchain/tqchain/mkchain.py
+++ b/mkchain/tqchain/mkchain.py
@@ -70,7 +70,7 @@ cli_args = {
     },
     "octez_docker_image": {
         "help": "Version of the Octez docker image",
-        "default": "tezos/tezos:v16.1",
+        "default": "tezos/tezos:v17.1",
     },
     "use_docker": {
         "action": "store_true",
@@ -188,7 +188,7 @@ def main():
         },
         "protocols": [
             {
-                "command": "PtMumbai",
+                "command": "PtNairob",
                 "vote": {"liquidity_baking_toggle_vote": "pass"},
             }
         ],
@@ -294,7 +294,7 @@ def main():
         parametersYaml = yaml.safe_load(yaml_file)
         activation = {
             "activation": {
-                "protocol_hash": "PtMumbai2TmsJHNGRkD8v8YDbtao7BLUC3wjASn1inAKLFCjaH1",
+                "protocol_hash": "PtNairobiyssHuh87hEhfVBGCVrK3WnS8Z2FT4ymB5tAa4r1nQf",
                 "protocol_parameters": parametersYaml,
             },
         }

--- a/mkchain/tqchain/parameters.yaml
+++ b/mkchain/tqchain/parameters.yaml
@@ -58,10 +58,11 @@ dal_parametric:
   number_of_slots: 256
   number_of_shards: 2048
   attestation_lag: 2
-  availability_threshold: 50
+  attestation_threshold: 50
   slot_size: 1048576
   redundancy_factor: 16
   page_size: 4096
+  blocks_per_epoch: 8
 smart_rollup_enable: true
 smart_rollup_origination_size: 6314
 smart_rollup_challenge_window_in_blocks: 40

--- a/test/charts/mainnet.expect.yaml
+++ b/test/charts/mainnet.expect.yaml
@@ -38,7 +38,7 @@ data:
   ARCHIVE_TARBALL_URL: ""
   PREFER_TARBALLS: "false"
   SNAPSHOT_SOURCE: "https://xtz-shots.io/tezos-snapshots.json"
-  OCTEZ_VERSION: "tezos/tezos:v16.1"
+  OCTEZ_VERSION: "tezos/tezos:v17.1"
   NODE_GLOBALS: |
     {
       "env": {}
@@ -127,7 +127,7 @@ spec:
     spec:
       containers:        
         - name: octez-node
-          image: "tezos/tezos:v16.1"
+          image: "tezos/tezos:v17.1"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -212,7 +212,7 @@ spec:
               memory: 80Mi        
       initContainers:        
         - name: config-init
-          image: "tezos/tezos:v16.1"
+          image: "tezos/tezos:v17.1"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -323,7 +323,7 @@ spec:
             - mountPath: /var/tezos
               name: var-volume        
         - name: snapshot-importer
-          image: "tezos/tezos:v16.1"
+          image: "tezos/tezos:v17.1"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -386,7 +386,7 @@ spec:
             - mountPath: /var/tezos
               name: var-volume                
         - name: upgrade-storage
-          image: "tezos/tezos:v16.1"
+          image: "tezos/tezos:v17.1"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh

--- a/test/charts/mainnet2.expect.yaml
+++ b/test/charts/mainnet2.expect.yaml
@@ -38,7 +38,7 @@ data:
   ARCHIVE_TARBALL_URL: ""
   PREFER_TARBALLS: "false"
   SNAPSHOT_SOURCE: "https://xtz-shots.io/tezos-snapshots.json"
-  OCTEZ_VERSION: "tezos/tezos:v16.1"
+  OCTEZ_VERSION: "tezos/tezos:v17.1"
   NODE_GLOBALS: |
     {
       "env": {
@@ -194,7 +194,7 @@ spec:
     spec:
       containers:        
         - name: octez-node
-          image: "tezos/tezos:v16.1"
+          image: "tezos/tezos:v17.1"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -315,7 +315,7 @@ spec:
               memory: 80Mi        
       initContainers:        
         - name: config-init
-          image: "tezos/tezos:v16.1"
+          image: "tezos/tezos:v17.1"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -432,7 +432,7 @@ spec:
             - mountPath: /var/tezos
               name: var-volume        
         - name: snapshot-importer
-          image: "tezos/tezos:v16.1"
+          image: "tezos/tezos:v17.1"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -497,7 +497,7 @@ spec:
             - mountPath: /var/tezos
               name: var-volume                
         - name: upgrade-storage
-          image: "tezos/tezos:v16.1"
+          image: "tezos/tezos:v17.1"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh


### PR DESCRIPTION
As usual:

* mkchain chain gets activated using nairobi proposal
* bump version by default to v17

See previous PR for reference: https://github.com/oxheadalpha/tezos-k8s/pull/538