### PR TITLE
snapshotEngine: Skip arm64 build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,7 +195,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           file: ${{ matrix.container }}/Dockerfile
           context: ${{ matrix.container}}/.
-          platforms: linux/amd64,linux/arm64
+          # Skips arm64 build for snapshotEngine
+          platforms: ${{ matrix.container!= 'snapshotEngine' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
 
           # Cache settings
           builder: ${{ steps.buildx.outputs.name }}


### PR DESCRIPTION
Something with our setup and the newest jsonschema 4.18.0 broke in arm64. I am unable to reproduce this on `alpine:latest`, and I think this is a better solution to skip the arm64 build of snapshotEngine altogether.