### PR TITLE
Add local_storage_size option in values

### DIFF
--- a/charts/tezos/templates/nodes.yaml
+++ b/charts/tezos/templates/nodes.yaml
@@ -86,7 +86,7 @@ spec:
         resources:
           requests:
 {{- if $.node_vals.local_storage | default false }}
-            storage: "1Gi"
+            storage: {{ default "1Gi" $.node_vals.local_storage_size }}
 {{- else }}
             storage: {{ default "15Gi" $.node_vals.storage_size }}
 {{- end }}

--- a/charts/tezos/templates/nodes.yaml
+++ b/charts/tezos/templates/nodes.yaml
@@ -86,7 +86,7 @@ spec:
         resources:
           requests:
 {{- if $.node_vals.local_storage | default false }}
-            storage: {{ default "1Gi" $.node_vals.local_storage_size }}
+            storage: {{ default "1Gi" $.node_vals.local_storage_pv_size }}
 {{- else }}
             storage: {{ default "15Gi" $.node_vals.storage_size }}
 {{- end }}

--- a/charts/tezos/values.yaml
+++ b/charts/tezos/values.yaml
@@ -151,7 +151,7 @@ should_generate_unsafe_deterministic_data: false
 # - "local_storage": use local storage instead of a volume. The storage will be
 #                  wiped when the node restarts for any reason. Useful when
 #                  faster IO is desired. Defaults to false.
-# - "local_storage_size": the size of the persistent volume to store identity.json and peers.json
+# - "local_storage_pv_size": the size of the persistent volume to store identity.json and peers.json
 #                            when local_storage is enabled, default value is 1Gi. Some cloud providers
 #                            would have minimum pv size requirement, for which this value can be used.
 # - "labels": https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/

--- a/charts/tezos/values.yaml
+++ b/charts/tezos/values.yaml
@@ -151,6 +151,9 @@ should_generate_unsafe_deterministic_data: false
 # - "local_storage": use local storage instead of a volume. The storage will be
 #                  wiped when the node restarts for any reason. Useful when
 #                  faster IO is desired. Defaults to false.
+# - "local_storage_size": the size of the persistent volume to store identity.json and peers.json
+#                            when local_storage is enabled, default value is 1Gi. Some cloud providers
+#                            would have minimum pv size requirement, for which this value can be used.
 # - "labels": https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 #      NOTE: the labels appType, node_class, and baking_node are set
 #      automatically for you.


### PR DESCRIPTION
Some cloud provider have minimum pvc size requirement, like Aliyun, this option would also tezos-k8s to be deployed under such scenarios.