### PR TITLE
Fix missing vote files + misc cleanup

### DIFF
--- a/charts/tezos/scripts/baker.sh
+++ b/charts/tezos/scripts/baker.sh
@@ -21,7 +21,12 @@ fi
 
 per_block_vote_file=/etc/tezos/baker-config/${my_baker_account}-${proto_command}-per-block-votes.json
 
-if [ $(cat $per_block_vote_file) == "null" ]; then
+if [ ! -f "$per_block_vote_file" ]; then
+  echo "Error: $per_block_vote_file not found" >&2
+  exit 1
+fi
+
+if [ "$(cat $per_block_vote_file)" == "null" ]; then
   cat << EOF
 You must pass per-block-votes (such as liquidity_baking_toggle_vote) in values.yaml, for example:
 protocols:

--- a/charts/tezos/templates/_helpers.tpl
+++ b/charts/tezos/templates/_helpers.tpl
@@ -114,6 +114,28 @@ metadata:
 {{- end }}
 
 {{/*
+  Get list of accounts that are being used to bake. Returned as a json
+  serialized dict because of how Helm renders everything returned from
+  a template as string. Function callers need to parse the returned
+  value like so: `fromJson | values | first`. A dict and not list is
+  returned because of the way `fromJson` works which expects a type of
+  map[string]interface {}.
+*/}}
+{{- define "tezos.getAccountsBaking" }}
+  {{- $allAccounts := list }}
+  {{- range $node := .Values.nodes }}
+    {{- range $instance := $node.instances }}
+    {{- if and .bake_using_accounts (kindIs "slice" .bake_using_accounts) }}
+        {{- $allAccounts = concat $allAccounts .bake_using_accounts }}
+      {{- else if and .bake_using_account (kindIs "string" .bake_using_account) }}
+        {{- $allAccounts = append $allAccounts .bake_using_account }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+  {{- dict "data" (uniq $allAccounts) | toJson }}
+{{- end }}
+
+{{/*
   Should deploy TZKT indexer?
 */}}
 {{- define "tezos.shouldDeployTzktIndexer" -}}

--- a/charts/tezos/templates/configs.yaml
+++ b/charts/tezos/templates/configs.yaml
@@ -91,13 +91,22 @@ metadata:
 {{- if (include "tezos.shouldDeployBakerConfig" .) }}
 apiVersion: v1
 data:
-{{- range $k, $v := .Values.accounts }}
-{{- range ( $v.protocols | default $.Values.protocols ) }}
-  {{ $k }}-{{ .command }}-per-block-votes.json: {{ .vote | toJson | quote }}
-{{- end }}
-{{- if $v.operations_pool }}
-  {{ $k }}_operations_pool: {{ $v.operations_pool | quote }}
-{{- end }}
+{{- $accountsBaking := include "tezos.getAccountsBaking" . | fromJson | values | first }}
+{{- range $accountName := $accountsBaking }}
+  {{- $account := get $.Values.accounts $accountName | default dict }}
+  {{- if and
+    (not $.Values.should_generate_unsafe_deterministic_data)
+    (not $account)
+   }}
+    {{- fail (printf "Baking account '%s' is not defined." $account) }}
+  {{- end }}
+
+  {{- range ( $account.protocols | default $.Values.protocols ) }}
+    {{ $accountName }}-{{ .command }}-per-block-votes.json: {{ .vote | toJson | quote }}
+  {{- end }}
+  {{- if $account.operations_pool }}
+    {{ $accountName }}_operations_pool: {{ $account.operations_pool | quote }}
+  {{- end }}
 {{- end }}
 kind: ConfigMap
 metadata:

--- a/charts/tezos/templates/nodes.yaml
+++ b/charts/tezos/templates/nodes.yaml
@@ -50,9 +50,11 @@ spec:
         fsGroup: 1000
 {{- include "tezos.nodeSelectorConfig" $ | indent 6 }}
       volumes:
+      {{- if (include "tezos.doesZerotierConfigExist" $) }}
         - hostPath:
             path: /dev/net/tun
           name: dev-net-tun
+      {{- end }}
         - emptyDir: {}
           name: config-volume
         - name: tezos-accounts

--- a/charts/tezos/values.yaml
+++ b/charts/tezos/values.yaml
@@ -126,11 +126,11 @@ should_generate_unsafe_deterministic_data: false
 # Said names are typically kebab case.
 #
 # Params at the statefulset level:
-# - "config": The "config" property should mimic the structure of a node's
+# - `config`: The "config" property should mimic the structure of a node's
 #             config.json. Run `octez-node config --help` for more info.
 #             If present at the statefulset level, it overrides it in
-#             node_globals.
-# - "env": a dictionary of containers mapped to a dictionary of env
+#             `node_globals`.
+# - `env`: A dictionary of containers mapped to a dictionary of env
 #          vars.  The container name "all" will apply the env vars to
 #          all containers.  The most specific wins.  Find the names of
 #          the containers by examining an installed environment, or by
@@ -138,28 +138,29 @@ should_generate_unsafe_deterministic_data: false
 #          that we truncate the protocol from the container name for
 #          bakers and accusers, so "baker-011-pthangz2" is configured
 #          using just "baker".
-# - "storage_size": the size of the PV
-# - "resources": resources specifications for the node.
+# - `storage_size`: The size of the PV.
+# - `resources`: Resources specifications for the node.
 #                Optionally set resources and limits for octez node
 #                See: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-# - "images": Optional specification of images to use for the tezos node and
+# - `images`: Optional specification of images to use for the tezos node and
 #           baker. Options are "octez" with a tezos/tezos image.
 #           If no images are provided, the containers will default to the images
 #           defined in the "images" field up above.
-# - "runs": A list of containers to run.
-#         Options being "octez_node", "accuser", "baker", "logger" and "vdf".
-# - "local_storage": use local storage instead of a volume. The storage will be
+# - `runs`: A list of containers to run.
+#         Options being `octez_node`, `accuser`, `baker`, `logger` and `vdf`.
+# - `local_storage`: Use local storage instead of a volume. The storage will be
 #                  wiped when the node restarts for any reason. Useful when
 #                  faster IO is desired. Defaults to false.
-# - "local_storage_pv_size": the size of the persistent volume to store identity.json and peers.json
-#                            when local_storage is enabled, default value is 1Gi. Some cloud providers
-#                            would have minimum pv size requirement, for which this value can be used.
-# - "labels": https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
-#      NOTE: the labels appType, node_class, and baking_node are set
+# - `local_storage_pv_size`: The size of the persistent volume to store `identity.json`
+#                            and `peers.json` when `local_storage` is enabled. Some cloud
+#                            providers have minimum pv size requirements for which this
+#                            value can be used. Default value is 1Gi.
+# - `labels`: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+#      NOTE: the labels `appType`, `node_class`, and `baking_node` are set
 #      automatically for you.
-# - "node_selector": Specify a kubernetes node selector in 'key: value' format
+# - `node_selector`: Specify a kubernetes node selector in `key: value` format
 #     for your tezos nodes.
-# - "readiness_probe": Attach a probe to the node. The probe checks whether
+# - `readiness_probe`: Attach a probe to the node. The probe checks whether
 #                    the most recent block is recent enough. If not, the
 #                    services will be unreachable. Defaults to True.
 #                    True is good for RPC nodes, private nodes, and
@@ -168,23 +169,25 @@ should_generate_unsafe_deterministic_data: false
 #                    chain with external bakers, such as a new test chain.
 #                    Otherwise, the chain may become unreachable externally
 #                    while waiting for other nodes to come online.
-# - "instances": a list of nodes to fire up, each is a dictionary defining:
-#    - "bake_using_account": Account name that should be used for baking.
-#    - "bake_using_accounts": List of account names that should be used for baking.
-#    - "config": Same as the outer statefulset level "config". It overrides the
+# - `instances`: A list of nodes to fire up, each is a dictionary defining:
+#    - `bake_using_account`: Account name that should be used for baking.
+#                            Don't also set `bake_using_accounts`.
+#    - `bake_using_accounts`: List of account names that should be used for baking.
+#                            Don't also set `bake_using_account`.
+#    - `config`: Same as the outer statefulset level `config`. It overrides the
 #                statefulset level.
-#    - "is_bootstrap_node": Is this node a bootstrap peer.
-#    - "identity": An optional map containing a pre-generated Tezos node
+#    - `is_bootstrap_node`: Boolean for is this node a bootstrap peer.
+#    - `identity`: An optional map containing a pre-generated Tezos node
 #                 identity. This is useful for local storage nodes which would
 #                 need to generate an identity at every boot. The identity file
 #                 will be created at /var/tezos/node/data/identity.json.
-#                 Required fields are "peer_id", "public_key", "secret_key",
-#                 and "proof_of_work_timestamp".
+#                 Required fields are `peer_id`, `public_key`, `secret_key`,
+#                 and `proof_of_work_timestamp`.
 #
 # Defaults are filled in for most of the above values.  You can also provide
-# global defaults for all nodes via a node_globals: section which is also
-# a dictionary.  Currently, two keys are defined: "config" and "env".  These
-# operate in the same way as the section in "nodes" going by the same name.
+# global defaults for all nodes via a `node_globals` section which is also
+# a dictionary.  Currently, two keys are defined: `config` and `env`.  These
+# operate in the same way as the section in `nodes` going by the same name.
 #
 # Example config:
 #
@@ -251,6 +254,7 @@ should_generate_unsafe_deterministic_data: false
 # ```
 # The default configuration is:
 node_globals:
+  config: {}
   env: {}
 nodes:
   rolling-node:

--- a/test/charts/mainnet.expect.yaml
+++ b/test/charts/mainnet.expect.yaml
@@ -41,6 +41,7 @@ data:
   OCTEZ_VERSION: "tezos/tezos:v17.1"
   NODE_GLOBALS: |
     {
+      "config": {},
       "env": {}
     }
 

--- a/test/charts/mainnet.expect.yaml
+++ b/test/charts/mainnet.expect.yaml
@@ -414,9 +414,6 @@ spec:
       securityContext:
         fsGroup: 1000      
       volumes:
-        - hostPath:
-            path: /dev/net/tun
-          name: dev-net-tun
         - emptyDir: {}
           name: config-volume
         - name: tezos-accounts

--- a/test/charts/mainnet2.expect.yaml
+++ b/test/charts/mainnet2.expect.yaml
@@ -527,9 +527,6 @@ spec:
       securityContext:
         fsGroup: 1000      
       volumes:
-        - hostPath:
-            path: /dev/net/tun
-          name: dev-net-tun
         - emptyDir: {}
           name: config-volume
         - name: tezos-accounts
@@ -905,9 +902,6 @@ spec:
       securityContext:
         fsGroup: 1000      
       volumes:
-        - hostPath:
-            path: /dev/net/tun
-          name: dev-net-tun
         - emptyDir: {}
           name: config-volume
         - name: tezos-accounts

--- a/test/charts/mainnet2.expect.yaml
+++ b/test/charts/mainnet2.expect.yaml
@@ -41,6 +41,7 @@ data:
   OCTEZ_VERSION: "tezos/tezos:v17.1"
   NODE_GLOBALS: |
     {
+      "config": {},
       "env": {
         "all": {
           "key": "outer-value"

--- a/test/charts/private-chain.expect.yaml
+++ b/test/charts/private-chain.expect.yaml
@@ -218,7 +218,12 @@ data:
 # Source: tezos-chain/templates/configs.yaml
 apiVersion: v1
 data:
-  tacoinfraSigner-013-PtJakart-per-block-votes.json: "{\"liquidity_baking_toggle_vote\":\"pass\"}"
+    tezos-baking-node-0-013-PtJakart-per-block-votes.json: "{\"liquidity_baking_toggle_vote\":\"pass\"}"
+    a-013-PtJakart-per-block-votes.json: "{\"liquidity_baking_toggle_vote\":\"pass\"}"
+    b-013-PtJakart-per-block-votes.json: "{\"liquidity_baking_toggle_vote\":\"pass\"}"
+    c-013-PtJakart-per-block-votes.json: "{\"liquidity_baking_toggle_vote\":\"pass\"}"
+    d-013-PtJakart-per-block-votes.json: "{\"liquidity_baking_toggle_vote\":\"pass\"}"
+    tacoinfraSigner-013-PtJakart-per-block-votes.json: "{\"liquidity_baking_toggle_vote\":\"pass\"}"
 kind: ConfigMap
 metadata:
   name: baker-config
@@ -682,9 +687,6 @@ spec:
       securityContext:
         fsGroup: 1000      
       volumes:
-        - hostPath:
-            path: /dev/net/tun
-          name: dev-net-tun
         - emptyDir: {}
           name: config-volume
         - name: tezos-accounts
@@ -806,7 +808,12 @@ spec:
               
               per_block_vote_file=/etc/tezos/baker-config/${my_baker_account}-${proto_command}-per-block-votes.json
               
-              if [ $(cat $per_block_vote_file) == "null" ]; then
+              if [ ! -f "$per_block_vote_file" ]; then
+                echo "Error: $per_block_vote_file not found" >&2
+                exit 1
+              fi
+              
+              if [ "$(cat $per_block_vote_file)" == "null" ]; then
                 cat << EOF
               You must pass per-block-votes (such as liquidity_baking_toggle_vote) in values.yaml, for example:
               protocols:
@@ -878,7 +885,12 @@ spec:
               
               per_block_vote_file=/etc/tezos/baker-config/${my_baker_account}-${proto_command}-per-block-votes.json
               
-              if [ $(cat $per_block_vote_file) == "null" ]; then
+              if [ ! -f "$per_block_vote_file" ]; then
+                echo "Error: $per_block_vote_file not found" >&2
+                exit 1
+              fi
+              
+              if [ "$(cat $per_block_vote_file)" == "null" ]; then
                 cat << EOF
               You must pass per-block-votes (such as liquidity_baking_toggle_vote) in values.yaml, for example:
               protocols:
@@ -950,7 +962,12 @@ spec:
               
               per_block_vote_file=/etc/tezos/baker-config/${my_baker_account}-${proto_command}-per-block-votes.json
               
-              if [ $(cat $per_block_vote_file) == "null" ]; then
+              if [ ! -f "$per_block_vote_file" ]; then
+                echo "Error: $per_block_vote_file not found" >&2
+                exit 1
+              fi
+              
+              if [ "$(cat $per_block_vote_file)" == "null" ]; then
                 cat << EOF
               You must pass per-block-votes (such as liquidity_baking_toggle_vote) in values.yaml, for example:
               protocols:
@@ -1022,7 +1039,12 @@ spec:
               
               per_block_vote_file=/etc/tezos/baker-config/${my_baker_account}-${proto_command}-per-block-votes.json
               
-              if [ $(cat $per_block_vote_file) == "null" ]; then
+              if [ ! -f "$per_block_vote_file" ]; then
+                echo "Error: $per_block_vote_file not found" >&2
+                exit 1
+              fi
+              
+              if [ "$(cat $per_block_vote_file)" == "null" ]; then
                 cat << EOF
               You must pass per-block-votes (such as liquidity_baking_toggle_vote) in values.yaml, for example:
               protocols:
@@ -1094,7 +1116,12 @@ spec:
               
               per_block_vote_file=/etc/tezos/baker-config/${my_baker_account}-${proto_command}-per-block-votes.json
               
-              if [ $(cat $per_block_vote_file) == "null" ]; then
+              if [ ! -f "$per_block_vote_file" ]; then
+                echo "Error: $per_block_vote_file not found" >&2
+                exit 1
+              fi
+              
+              if [ "$(cat $per_block_vote_file)" == "null" ]; then
                 cat << EOF
               You must pass per-block-votes (such as liquidity_baking_toggle_vote) in values.yaml, for example:
               protocols:
@@ -1272,9 +1299,6 @@ spec:
       securityContext:
         fsGroup: 1000      
       volumes:
-        - hostPath:
-            path: /dev/net/tun
-          name: dev-net-tun
         - emptyDir: {}
           name: config-volume
         - name: tezos-accounts
@@ -1476,9 +1500,6 @@ spec:
       securityContext:
         fsGroup: 1000      
       volumes:
-        - hostPath:
-            path: /dev/net/tun
-          name: dev-net-tun
         - emptyDir: {}
           name: config-volume
         - name: tezos-accounts

--- a/test/charts/private-chain.expect.yaml
+++ b/test/charts/private-chain.expect.yaml
@@ -134,6 +134,7 @@ data:
   OCTEZ_VERSION: "tezos/tezos:v15-release"
   NODE_GLOBALS: |
     {
+      "config": {},
       "env": {}
     }
 


### PR DESCRIPTION
- Fixes bash script that checks for vote files for bakers. Script had bug if the files it expected didn't exist.
- Fixes missing vote files for accounts that will be created automatically via `should_generate_unsafe_deterministic_data`.
- closes https://github.com/oxheadalpha/tezos-k8s/issues/284
- Does a little cleanup in values.yaml so published docs on tezos-k8s.xyz has more markdown formatting.