### PR TITLE
update pyyaml to 6.0.1

### DIFF
--- a/rpc-auth/requirements.txt
+++ b/rpc-auth/requirements.txt
@@ -22,7 +22,7 @@ pysodium==0.7.5
 pytezos==2.5.11
 python-dateutil==2.8.1
 pytzdata==2020.1
-PyYAML==5.4
+PyYAML==6.0.1
 redis==3.5.3
 requests==2.26.0
 secp256k1==0.13.2


### PR DESCRIPTION
Fixes broken pyyaml arm64 build in our CI.