### PR TITLE
PoW Faucet

### DIFF
--- a/charts/tezos-faucet/Chart.yaml
+++ b/charts/tezos-faucet/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 2.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.16.0
+appVersion: 2.0.0

--- a/charts/tezos-faucet/templates/configmap.yaml
+++ b/charts/tezos-faucet/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.enableUI }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -11,17 +12,18 @@ data:
 {{- end }}
 {{- $_ := set .Values.config.application "profiles" $newProfiles }}
 {{ .Values.config | mustToPrettyJson | indent 4 }}
-
 ---
+{{- end }}
+
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: faucet-backend-config
   namespace: {{ .Release.Namespace }}
 data:
-  AUTHORIZED_HOST: {{ .Values.authorizedHost }}
+  AUTHORIZED_HOST: "{{ .Values.authorizedHost }}"
   DISABLE_CHALLENGES: "{{ .Values.disableChallenges }}"
   ENABLE_CAPTCHA: "{{ .Values.enableCaptcha }}"
   MAX_BALANCE: "{{ .Values.maxBalance }}"
-  REDIS_URL: {{ .Values.redis.url }}
-  RPC_URL: {{ .Values.config.network.rpcUrl }}
+  REDIS_URL: "{{ .Values.redis.url }}"
+  RPC_URL: "{{ required "config.network.rpcUrl is required." .Values.config.network.rpcUrl }}"

--- a/charts/tezos-faucet/templates/configmap.yaml
+++ b/charts/tezos-faucet/templates/configmap.yaml
@@ -11,6 +11,7 @@ data:
   {{- $newProfiles = set $newProfiles $key (pick $value "amount" "profile") }}
 {{- end }}
 {{- $_ := set .Values.config.application "profiles" $newProfiles }}
+{{- $_ := set .Values.config.application "disableChallenges" .Values.disableChallenges }}
 {{ .Values.config | mustToPrettyJson | indent 4 }}
 ---
 {{- end }}

--- a/charts/tezos-faucet/templates/configmap.yaml
+++ b/charts/tezos-faucet/templates/configmap.yaml
@@ -26,4 +26,4 @@ data:
   ENABLE_CAPTCHA: "{{ .Values.enableCaptcha }}"
   MAX_BALANCE: "{{ .Values.maxBalance }}"
   REDIS_URL: "{{ .Values.redis.url }}"
-  RPC_URL: "{{ required "config.network.rpcUrl is required." .Values.config.network.rpcUrl }}"
+  RPC_URL: "{{ .Values.backendRpcUrl | default .Values.config.network.rpcUrl | required "An rpc url is required." }}"

--- a/charts/tezos-faucet/templates/configmap.yaml
+++ b/charts/tezos-faucet/templates/configmap.yaml
@@ -22,6 +22,8 @@ metadata:
   name: faucet-backend-config
   namespace: {{ .Release.Namespace }}
 data:
+  profiles.json: {{ .Values.profiles | mustToPrettyJson | quote }}
+
   AUTHORIZED_HOST: "{{ .Values.authorizedHost }}"
   DISABLE_CHALLENGES: "{{ .Values.disableChallenges }}"
   ENABLE_CAPTCHA: "{{ .Values.enableCaptcha }}"

--- a/charts/tezos-faucet/templates/configmap.yaml
+++ b/charts/tezos-faucet/templates/configmap.yaml
@@ -1,11 +1,17 @@
 apiVersion: v1
-data:
-  config.json: |
-{{ .Values.config | mustToPrettyJson | indent 4 }}
 kind: ConfigMap
 metadata:
   name: faucet-config
   namespace: {{ .Release.Namespace }}
+data:
+  config.json: |
+{{- $newProfiles := dict }}
+{{- range $key, $value :=  .Values.profiles }}
+  {{- $newProfiles = set $newProfiles $key (pick $value "amount" "profile") }}
+{{- end }}
+{{- $_ := set .Values.config.application "profiles" $newProfiles }}
+{{ .Values.config | mustToPrettyJson | indent 4 }}
+
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -13,9 +19,9 @@ metadata:
   name: faucet-backend-config
   namespace: {{ .Release.Namespace }}
 data:
-  FAUCET_ADDRESS: {{ .Values.config.network.faucetAddress }}
-  RPC_URL: {{ .Values.config.network.rpcUrl }}
   AUTHORIZED_HOST: {{ .Values.authorizedHost }}
-  FAUCET_AMOUNT_USER: "{{ .Values.config.application.profiles.user.amount}}"
-  FAUCET_AMOUNT_BAKER: "{{ .Values.config.application.profiles.baker.amount}}"
+  DISABLE_CHALLENGES: "{{ .Values.disableChallenges }}"
+  ENABLE_CAPTCHA: "{{ .Values.enableCaptcha }}"
   MAX_BALANCE: "{{ .Values.maxBalance }}"
+  REDIS_URL: {{ .Values.redis.url }}
+  RPC_URL: {{ .Values.config.network.rpcUrl }}

--- a/charts/tezos-faucet/templates/deployment.yaml
+++ b/charts/tezos-faucet/templates/deployment.yaml
@@ -15,7 +15,7 @@ spec:
       annotations:
         # ensure that the pod bounces each time configmap changes
         # https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }} 
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
       containers:
       - image: {{ .Values.images.tezos_faucet_backend }}
@@ -37,12 +37,11 @@ spec:
           protocol: TCP
         volumeMounts:
         - name: faucet-config
-          mountPath: "/app/src/config.json"
-          subPath: "config.json"
+          mountPath: /app/public/config.json
+          subPath: config.json
           readOnly: true
       restartPolicy: Always
       volumes:
       - name: faucet-config
         configMap:
           name: faucet-config
-status: {}

--- a/charts/tezos-faucet/templates/deployment.yaml
+++ b/charts/tezos-faucet/templates/deployment.yaml
@@ -17,6 +17,7 @@ spec:
         # https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
+      restartPolicy: Always
       containers:
       - image: {{ .Values.images.tezosFaucetBackend }}
         name: faucet-backend
@@ -29,6 +30,7 @@ spec:
             name: faucet-backend-config
         - secretRef:
             name: faucet-backend-secret
+    {{- if .Values.enableUI }}
       - image: {{ .Values.images.tezosFaucet }}
         name: faucet
         ports:
@@ -40,8 +42,8 @@ spec:
           mountPath: /app/public/config.json
           subPath: config.json
           readOnly: true
-      restartPolicy: Always
       volumes:
       - name: faucet-config
         configMap:
           name: faucet-config
+    {{- end }}

--- a/charts/tezos-faucet/templates/deployment.yaml
+++ b/charts/tezos-faucet/templates/deployment.yaml
@@ -26,8 +26,9 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
-        - image: {{ .Values.images.tezosFaucetBackend }}
-          name: faucet-backend
+        - name: faucet-backend
+          image: {{ .Values.images.tezosFaucetBackend }}
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           ports:
@@ -51,8 +52,9 @@ spec:
               subPath: profiles.json
               readOnly: true
       {{- if .Values.enableUI }}
-        - image: {{ .Values.images.tezosFaucet }}
-          name: faucet
+        - name: faucet
+          image: {{ .Values.images.tezosFaucet }}
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           ports:

--- a/charts/tezos-faucet/templates/deployment.yaml
+++ b/charts/tezos-faucet/templates/deployment.yaml
@@ -18,7 +18,7 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
       containers:
-      - image: {{ .Values.images.tezos_faucet_backend }}
+      - image: {{ .Values.images.tezosFaucetBackend }}
         name: faucet-backend
         ports:
         - name: backend
@@ -29,7 +29,7 @@ spec:
             name: faucet-backend-config
         - secretRef:
             name: faucet-backend-secret
-      - image: {{ .Values.images.tezos_faucet }}
+      - image: {{ .Values.images.tezosFaucet }}
         name: faucet
         ports:
         - name: frontend

--- a/charts/tezos-faucet/templates/deployment.yaml
+++ b/charts/tezos-faucet/templates/deployment.yaml
@@ -18,32 +18,57 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
       restartPolicy: Always
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "tezos-faucet.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
-      - image: {{ .Values.images.tezosFaucetBackend }}
-        name: faucet-backend
-        ports:
-        - name: backend
-          containerPort: 3000
-          protocol: TCP
-        envFrom:
-        - configMapRef:
-            name: faucet-backend-config
-        - secretRef:
-            name: faucet-backend-secret
+        - image: {{ .Values.images.tezosFaucetBackend }}
+          name: faucet-backend
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          ports:
+            - name: backend
+              containerPort: 3000
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: faucet-backend-config
+            - secretRef:
+                name: faucet-backend-secret
     {{- if .Values.enableUI }}
-      - image: {{ .Values.images.tezosFaucet }}
-        name: faucet
-        ports:
-        - name: frontend
-          containerPort: 8080
-          protocol: TCP
-        volumeMounts:
-        - name: faucet-config
-          mountPath: /app/public/config.json
-          subPath: config.json
-          readOnly: true
+        - image: {{ .Values.images.tezosFaucet }}
+          name: faucet
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          ports:
+            - name: frontend
+              containerPort: 8080
+              protocol: TCP
+          volumeMounts:
+            - name: faucet-config
+              mountPath: /app/public/config.json
+              subPath: config.json
+              readOnly: true
       volumes:
-      - name: faucet-config
-        configMap:
-          name: faucet-config
+        - name: faucet-config
+          configMap:
+            name: faucet-config
+
     {{- end }}
+
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/tezos-faucet/templates/deployment.yaml
+++ b/charts/tezos-faucet/templates/deployment.yaml
@@ -40,9 +40,9 @@ spec:
             - secretRef:
                 name: faucet-backend-secret
           env:
-          # profiles.json gets set via the configmap. We store it there for easy
-          # access to mount as a file instead of in a new configmap. We don't
-          # need it to be an env var so we make it empty here.
+          # profiles.json is stored in faucet-backend-config instead of in a new
+          # dedicated configmap. We don't need it to be an env var so we make it
+          # empty here to counteract envFrom.
             - name: profiles.json
               value: ""
           volumeMounts:

--- a/charts/tezos-faucet/templates/deployment.yaml
+++ b/charts/tezos-faucet/templates/deployment.yaml
@@ -39,7 +39,18 @@ spec:
                 name: faucet-backend-config
             - secretRef:
                 name: faucet-backend-secret
-    {{- if .Values.enableUI }}
+          env:
+          # profiles.json gets set via the configmap. We store it there for easy
+          # access to mount as a file instead of in a new configmap. We don't
+          # need it to be an env var so we make it empty here.
+            - name: profiles.json
+              value: ""
+          volumeMounts:
+            - name: faucet-backend-config
+              mountPath: /app/dist/profiles.json
+              subPath: profiles.json
+              readOnly: true
+      {{- if .Values.enableUI }}
         - image: {{ .Values.images.tezosFaucet }}
           name: faucet
           securityContext:
@@ -53,12 +64,16 @@ spec:
               mountPath: /app/public/config.json
               subPath: config.json
               readOnly: true
+      {{- end }}
       volumes:
+        - name: faucet-backend-config
+          configMap:
+            name: faucet-backend-config
+      {{- if .Values.enableUI }}
         - name: faucet-config
           configMap:
             name: faucet-config
-
-    {{- end }}
+      {{- end }}
 
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/tezos-faucet/templates/ingress.yaml
+++ b/charts/tezos-faucet/templates/ingress.yaml
@@ -15,6 +15,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tezos-faucet.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
@@ -48,11 +49,14 @@ spec:
                 port:
                   number: 3000
           {{- end }}
+
+        {{- if .Values.enableUI }}
           - path: /
-            pathType: 'Prefix'
+            pathType: Prefix
             backend:
               service:
                 name: {{ $fullName }}
                 port:
                   number: 8080
+        {{- end }}
 {{- end }}

--- a/charts/tezos-faucet/templates/ingress.yaml
+++ b/charts/tezos-faucet/templates/ingress.yaml
@@ -1,6 +1,5 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := "tezos-faucet" -}}
-{{- $svcPort := .Values.service.port -}}
 {{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
   {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
   {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
@@ -40,25 +39,20 @@ spec:
     - host: {{ .Values.ingress.host | quote }}
       http:
         paths:
-        - path: "/info"
-          pathType: 'Prefix'
-          backend:
-            service:
-              name: {{ $fullName }}
-              port:
-                number: 3000
-        - path: "/send"
-          pathType: 'Prefix'
-          backend:
-            service:
-              name: {{ $fullName }}
-              port:
-                number: 3000
-        - path: "/"
-          pathType: 'Prefix'
-          backend:
-            service:
-              name: {{ $fullName }}
-              port:
-                number: 8080
+          {{- range $path := list "/info" "/challenge" "/verify" }}
+          - path: {{ $path }}
+            pathType: Exact
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: 3000
+          {{- end }}
+          - path: /
+            pathType: 'Prefix'
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: 8080
 {{- end }}

--- a/charts/tezos-faucet/templates/secret.yaml
+++ b/charts/tezos-faucet/templates/secret.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: {{ .Release.Namespace }}
 data:
   CAPTCHA_SECRET: {{ .Values.googleCaptchaSecretKey | b64enc }}
-  FAUCET_PRIVATE_KEY: {{ .Values.faucetPrivateKey | b64enc }}
+  FAUCET_PRIVATE_KEY: {{ required "faucetPrivateKey is required." .Values.faucetPrivateKey | b64enc }}
   REDIS_PASSWORD: {{ .Values.redis.password | b64enc }}

--- a/charts/tezos-faucet/templates/secret.yaml
+++ b/charts/tezos-faucet/templates/secret.yaml
@@ -1,17 +1,9 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: faucet-secret
-  namespace: {{ .Release.Namespace }}
-data:
-  recaptcha_keys.json: |
-{{ .Values.recaptcha_keys | toJson | b64enc | indent 4 }}
----
-apiVersion: v1
-kind: Secret
-metadata:
   name: faucet-backend-secret
   namespace: {{ .Release.Namespace }}
 data:
+  CAPTCHA_SECRET: {{ .Values.googleCaptchaSecretKey | b64enc }}
   FAUCET_PRIVATE_KEY: {{ .Values.faucetPrivateKey | b64enc }}
-  FAUCET_CAPTCHA_SECRET: {{ .Values.googleCaptchaSecretKey | b64enc }}
+  REDIS_PASSWORD: {{ .Values.redis.password | b64enc }}

--- a/charts/tezos-faucet/templates/service.yaml
+++ b/charts/tezos-faucet/templates/service.yaml
@@ -7,14 +7,16 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   type: NodePort
+  selector:
+    app: tezos-faucet
   ports:
+  {{- if .Values.enableUI }}
     - name: frontend
       port: 8080
       targetPort: frontend
       protocol: TCP
+  {{- end }}
     - name: backend
       port: 3000
       targetPort: backend
       protocol: TCP
-  selector:
-    app: tezos-faucet

--- a/charts/tezos-faucet/templates/serviceaccount.yaml
+++ b/charts/tezos-faucet/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "tezos-faucet.serviceAccountName" . }}
+  labels:
+    {{- include "tezos-faucet.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/tezos-faucet/values.yaml
+++ b/charts/tezos-faucet/values.yaml
@@ -5,16 +5,19 @@ images:
   tezosFaucet: ghcr.io/oxheadalpha/tezos-faucet:latest
   tezosFaucetBackend: ghcr.io/oxheadalpha/tezos-faucet-backend:latest
 
-# Frontend application configuration.
+# Frontend app configuration. You can optionally deploy only the faucet backend.
+enableUI: true
 config:
   application:
     name: "Tezos Faucet"
     googleCaptchaSiteKey: "" # 6LefC8QmAAAAAIX...
-    backendUrl: "" # http://faucet-backend:3000
+    # Default value assumes faucet backend is available on localhost.
+    backendUrl: http://localhost:3000
     githubRepo: https://github.com/oxheadalpha/tezos-faucet
   network:
     name: Custom
-    rpcUrl: "" # http://tezos-node-rpc:8732
+    # Default value assumes node rpc is available on localhost.
+    rpcUrl: http://localhost:8732
     faucetAddress: "" # tz1PW...
     viewer: "" # https://network.tzstats.com
 

--- a/charts/tezos-faucet/values.yaml
+++ b/charts/tezos-faucet/values.yaml
@@ -1,33 +1,63 @@
+# Faucet backend: https://github.com/oxheadalpha/tezos-faucet-backend
+# Faucet frontend: https://github.com/oxheadalpha/tezos-faucet
+
 images:
-  tezos_faucet: ghcr.io/oxheadalpha/tezos-faucet:latest
-  tezos_faucet_backend: ghcr.io/oxheadalpha/tezos-faucet-backend:latest
-authorizedHost: "'*'"
+  tezosFaucet: ghcr.io/oxheadalpha/tezos-faucet:latest
+  tezosFaucetBackend: ghcr.io/oxheadalpha/tezos-faucet-backend:latest
 
-# if your balance is over the max, the faucet won't give you more tokens
-maxBalance: 12000
-
+# Frontend application configuration.
 config:
   application:
-     name: "Tezos Jakartanet faucet"
-     googleCaptchaSiteKey: #6LeiK14fAAAAAPptX4v49I4wSrHjOrU2cb_y5oII
-     backendUrl: "http://localhost:3000"
-     githubRepo: "https://github.com/oxheadalpha/tezos-faucet"
-     profiles:
-       user:
-         profile: USER
-         amount: 1
-       baker:
-         profile: BAKER
-         amount: 6000
+    name: "Tezos Faucet"
+    googleCaptchaSiteKey: "" # 6LefC8QmAAAAAIX...
+    backendUrl: "" # http://faucet-backend:3000
+    githubRepo: https://github.com/oxheadalpha/tezos-faucet
   network:
-     name: #Jakartanet
-     rpcUrl: #https://jakartanet.tezos.marigold.dev/
-     faucetAddress: #tz1cpdS3qoQBYCGohszPWS8Gdya6Wg2e4JnL
-     viewer: #https://jakarta.tzstats.com
-     allowSendButton: true
-service:
-  type: ClusterIP
-  port: 8080
+    name: Custom
+    rpcUrl: "" # http://tezos-node-rpc:8732
+    faucetAddress: "" # tz1PW...
+    viewer: "" # https://network.tzstats.com
+
+# Value the server sets for the "Access-Control-Allow-Origin" header for CORS.
+authorizedHost: "*"
+# If the backend requires captcha/
+enableCaptcha: true
+# Faucet won't dispense to an address if its balance exceeds this.
+maxBalance: 6000
+
+# Configuration for the faucet profiles. Each profile (e.g., 'user', 'baker') has specific parameters:
+#   - `profile`: The name of the profile.
+#   - `amount`: The amount of Tez to be distributed for this profile.
+#   - `challengesNeeded`: The number of PoW challenges to be solved when a CAPTCHA is not used.
+#   - `challengesNeededWithCaptcha`: The number of PoW challenges to be solved when a CAPTCHA is used.
+#   - `difficulty`: The difficulty level of the PoW challenge when a CAPTCHA is not used.
+#   - `difficultyWithCaptcha`: The difficulty level of the PoW challenge when a CAPTCHA is used.
+# These parameters control the distribution of Tez and the complexity of challenges to prevent spamming and abuse.
+profiles:
+  user:
+    profile: USER
+    amount: 1
+    challengesNeeded: 5
+    challengesNeededWithCaptcha: 4
+    difficulty: 4
+    difficultyWithCaptcha: 3
+  baker:
+    profile: BAKER
+    amount: 6000
+    challengesNeeded: 6
+    challengesNeededWithCaptcha: 5
+    difficulty: 5
+    difficultyWithCaptcha: 4
+
+# Set to true to disable the requirement of solving PoW challenges.
+disableChallenges: false
+
+# Config for the Redis backend for the PoW challenges. Redis is not needed if
+# challenges are disabled.
+redis:
+  url: "" # redis://redis-master.redis:6379
+  password: ""
+
 ingress:
   enabled: false
   className: ""
@@ -41,5 +71,5 @@ ingress:
   #      - chart-example-frontend.local
 
 # Secrets
-googleCaptchaSecretKey: secret_key_goes_here
-faucetPrivateKey: edsk***
+googleCaptchaSecretKey: "" # 6LefC8QmAAAAAPH...
+faucetPrivateKey: "" # edsk3X...

--- a/charts/tezos-faucet/values.yaml
+++ b/charts/tezos-faucet/values.yaml
@@ -26,7 +26,7 @@ authorizedHost: "*"
 # RPC url for the faucet backend. Default value assumes tezos-k8s created an RPC
 # service in the same namespace. If not set, defaults to `config.network.rpcUrl`.
 backendRpcUrl: http://tezos-node-rpc:8732
-# If the backend requires CAPTCHA token.
+# If the backend requires CAPTCHA tokens to be submitted.
 enableCaptcha: true
 # Faucet won't dispense to an address if its balance exceeds this.
 maxBalance: 6000
@@ -42,14 +42,12 @@ maxBalance: 6000
 # - `difficultyWithCaptcha`: Challenge difficulty level when CAPTCHA is used.
 profiles:
   user:
-    profile: USER
     amount: 1
     challengesNeeded: 5
     challengesNeededWithCaptcha: 4
     difficulty: 4
     difficultyWithCaptcha: 3
   baker:
-    profile: BAKER
     amount: 6000
     challengesNeeded: 6
     challengesNeededWithCaptcha: 5

--- a/charts/tezos-faucet/values.yaml
+++ b/charts/tezos-faucet/values.yaml
@@ -98,7 +98,7 @@ securityContext:
 serviceAccount:
   create: true
   annotations: {}
-  name: ""
+  name: tezos-faucet
 
 nodeSelector: {}
 

--- a/charts/tezos-faucet/values.yaml
+++ b/charts/tezos-faucet/values.yaml
@@ -65,6 +65,10 @@ redis:
   url: "" # redis://redis-master.redis:6379
   password: ""
 
+# Secrets
+googleCaptchaSecretKey: "" # 6LefC8QmAAAAAPH...
+faucetPrivateKey: "" # edsk3X...
+
 ingress:
   enabled: false
   className: ""
@@ -77,6 +81,29 @@ ingress:
   #    hosts:
   #      - chart-example-frontend.local
 
-# Secrets
-googleCaptchaSecretKey: "" # 6LefC8QmAAAAAPH...
-faucetPrivateKey: "" # edsk3X...
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/charts/tezos-faucet/values.yaml
+++ b/charts/tezos-faucet/values.yaml
@@ -2,8 +2,8 @@
 # Faucet frontend: https://github.com/oxheadalpha/tezos-faucet
 
 images:
-  tezosFaucet: ghcr.io/oxheadalpha/tezos-faucet:latest
-  tezosFaucetBackend: ghcr.io/oxheadalpha/tezos-faucet-backend:latest
+  tezosFaucet: ghcr.io/oxheadalpha/tezos-faucet:2.0.0
+  tezosFaucetBackend: ghcr.io/oxheadalpha/tezos-faucet-backend:2.0.0
 
 # Frontend app configuration. You can optionally deploy only the faucet backend.
 enableUI: true

--- a/charts/tezos-faucet/values.yaml
+++ b/charts/tezos-faucet/values.yaml
@@ -16,26 +16,30 @@ config:
     githubRepo: https://github.com/oxheadalpha/tezos-faucet
   network:
     name: Custom
-    # Default value assumes node rpc is available on localhost.
+    # Default value assumes node RPC is available on localhost.
     rpcUrl: http://localhost:8732
     faucetAddress: "" # tz1PW...
     viewer: "" # https://network.tzstats.com
 
 # Value the server sets for the "Access-Control-Allow-Origin" header for CORS.
 authorizedHost: "*"
-# If the backend requires captcha/
+# RPC url for the faucet backend. Default value assumes tezos-k8s created an RPC
+# service in the same namespace. If not set, defaults to `config.network.rpcUrl`.
+backendRpcUrl: http://tezos-node-rpc:8732
+# If the backend requires CAPTCHA token.
 enableCaptcha: true
 # Faucet won't dispense to an address if its balance exceeds this.
 maxBalance: 6000
 
-# Configuration for the faucet profiles. Each profile (e.g., 'user', 'baker') has specific parameters:
-#   - `profile`: The name of the profile.
-#   - `amount`: The amount of Tez to be distributed for this profile.
-#   - `challengesNeeded`: The number of PoW challenges to be solved when a CAPTCHA is not used.
-#   - `challengesNeededWithCaptcha`: The number of PoW challenges to be solved when a CAPTCHA is used.
-#   - `difficulty`: The difficulty level of the PoW challenge when a CAPTCHA is not used.
-#   - `difficultyWithCaptcha`: The difficulty level of the PoW challenge when a CAPTCHA is used.
-# These parameters control the distribution of Tez and the complexity of challenges to prevent spamming and abuse.
+# Configuration for the faucet profiles. To prevent spamming and abuse, each
+# profile has specific parameters that control the distribution of Tez and the
+# complexity and number of PoW challenges needed.
+# - `profile`: The name of the profile.
+# - `amount`: Amount of Tez to be distributed for this profile.
+# - `challengesNeeded`: Number of challenges given when CAPTCHA isn't used.
+# - `challengesNeededWithCaptcha`: Number of challenges given when CAPTCHA is used.
+# - `difficulty`: Challenge difficulty level when CAPTCHA isn't used.
+# - `difficultyWithCaptcha`: Challenge difficulty level when CAPTCHA is used.
 profiles:
   user:
     profile: USER

--- a/charts/tezos-faucet/values.yaml
+++ b/charts/tezos-faucet/values.yaml
@@ -79,6 +79,7 @@ ingress:
   #    hosts:
   #      - chart-example-frontend.local
 
+imagePullPolicy: IfNotPresent
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
Tezos faucet chart updates for the new PoW challenge functionality.

See https://github.com/oxheadalpha/tezos-faucet-backend/pull/2 and https://github.com/oxheadalpha/tezos-faucet/pull/16

Notable changes:
- Can configure separate RPC url for the backend code. This way the backend can query the k8s node rpc service directly.
- Deploying the frontend is now optional, so you can have just a programmatic faucet.
- Added pod security context, service account, plus other Helm k8s configuration options.
- Removed unused secret.
- General cleanup and improvement.