### PR TITLE
snapshotengine: move sleep to reduce volumes

### DIFF
--- a/snapshotEngine/zip-and-upload.sh
+++ b/snapshotEngine/zip-and-upload.sh
@@ -570,24 +570,6 @@ if [[ -n "${SNAPSHOT_WEBSITE_DOMAIN_NAME}" ]]; then
 
     # Upload chain page (index.html and assets) to root of website bucket
     eval "$(set_aws_command_creds "aws")" s3 cp _site/ s3://"${SNAPSHOT_WEBSITE_DOMAIN_NAME}" --recursive | grep "*"
+
+    exit 0
 fi
-
-SLEEP_TIME=0m
-
-if [ "${HISTORY_MODE}" = "archive" ]; then
-    SLEEP_TIME="${ARCHIVE_SLEEP_DELAY}"
-    if [ "${ARCHIVE_SLEEP_DELAY}" != "0m" ]; then
-        printf "%s artifactDelay.archive is set to %s sleeping...\n" "$(date "+%Y-%m-%d %H:%M:%S")" "${ARCHIVE_SLEEP_DELAY}"
-    fi
-elif [ "${HISTORY_MODE}" = "rolling" ]; then
-    SLEEP_TIME="${ROLLING_SLEEP_DELAY}"
-    if [ "${ROLLING_SLEEP_DELAY}" != "0m" ]; then
-        printf "%s artifactDelay.rolling is set to %s sleeping...\n" "$(date "+%Y-%m-%d %H:%M:%S")" "${ROLLING_SLEEP_DELAY}"
-    fi
-fi
-
-if [ "${SLEEP_TIME}" = "0m" ]; then
-    printf "%s artifactDelay.HISTORY_MODE was not set! No delay...\n" "$(date "+%Y-%m-%d %H:%M:%S")"
-fi
-
-sleep "${SLEEP_TIME}"


### PR DESCRIPTION
Currently the artifact job sleeps a user-defined amount of time to reduce frequency of artifact creation.  This resulted in PVCs remaining bound to the kubernetes nodes.  With the migration to Digital Ocean a new limit was encountered- only 7 volumes allowed per droplet(node) which was resulting in a need for more droplets.  

This PR moves moves the sleep out of the artifact creation job causing it to terminate. The maker job detects this, deletes the job and PVCs and sleeps instead freeing up slots.

Additional info- AWS volume-per-instance limit was at minimum 32 so this was not an issue, but is now on Digital Ocean because of the 7 volume limit per droplet.  The volume-per-droplet limit is hard platform limit and not changeable by Digital Ocean support.