### PR TITLE
chain activation: avoid misfiring

### DIFF
--- a/charts/tezos/scripts/chain-initiator.sh
+++ b/charts/tezos/scripts/chain-initiator.sh
@@ -1,20 +1,21 @@
 CLIENT="/usr/local/bin/octez-client --endpoint http://tezos-node-rpc:8732"
 
-until $CLIENT rpc get /chains/main/blocks/head/header | grep '"level":'; do
+OUTPUT=""
+until OUTPUT=$($CLIENT rpc get /chains/main/blocks/head/header) && echo "$OUTPUT" | grep '"level":'; do
     sleep 2
 done
 
 set -x
 set -o pipefail
-if ! $CLIENT rpc get /chains/main/blocks/head/header | grep '"level": 0,'; then
+if ! echo "$OUTPUT" | grep '"level": 0,'; then
     echo "Chain already activated, considering activation successful and exiting"
     exit 0
 fi
 
 echo Activating chain:
-$CLIENT -d /var/tezos/client --block					\
-	genesis activate protocol					\
-	{{ .Values.activation.protocol_hash }}				\
-	with fitness 1 and key						\
-	$( cat /etc/tezos/activation_account_name )			\
-	and parameters /etc/tezos/parameters.json 2>&1 | head -200
+$CLIENT -d /var/tezos/client --block                                    \
+        genesis activate protocol                                       \
+        {{ .Values.activation.protocol_hash }}                          \
+        with fitness 1 and key                                          \
+        $( cat /etc/tezos/activation_account_name )                     \
+        and parameters /etc/tezos/parameters.json 2>&1 | head -200

--- a/test/charts/private-chain.expect.yaml
+++ b/test/charts/private-chain.expect.yaml
@@ -1620,24 +1620,25 @@ spec:
             - |
               CLIENT="/usr/local/bin/octez-client --endpoint http://tezos-node-rpc:8732"
               
-              until $CLIENT rpc get /chains/main/blocks/head/header | grep '"level":'; do
+              OUTPUT=""
+              until OUTPUT=$($CLIENT rpc get /chains/main/blocks/head/header) && echo "$OUTPUT" | grep '"level":'; do
                   sleep 2
               done
               
               set -x
               set -o pipefail
-              if ! $CLIENT rpc get /chains/main/blocks/head/header | grep '"level": 0,'; then
+              if ! echo "$OUTPUT" | grep '"level": 0,'; then
                   echo "Chain already activated, considering activation successful and exiting"
                   exit 0
               fi
               
               echo Activating chain:
-              $CLIENT -d /var/tezos/client --block					\
-              	genesis activate protocol					\
-              	PtJakart2xVj7pYXJBXrqHgd82rdkLey5ZeeGwDgPp9rhQUbSqY				\
-              	with fitness 1 and key						\
-              	$( cat /etc/tezos/activation_account_name )			\
-              	and parameters /etc/tezos/parameters.json 2>&1 | head -200
+              $CLIENT -d /var/tezos/client --block                                    \
+                      genesis activate protocol                                       \
+                      PtJakart2xVj7pYXJBXrqHgd82rdkLey5ZeeGwDgPp9rhQUbSqY                          \
+                      with fitness 1 and key                                          \
+                      $( cat /etc/tezos/activation_account_name )                     \
+                      and parameters /etc/tezos/parameters.json 2>&1 | head -200
               
           envFrom:
           env:


### PR DESCRIPTION
when activate job gets a successful RPC response for the first time, it should not repeat the query; instead, just parse the output again and check whether the level is zero.

This way, if the second rpc query fails, it will just restart the job instead of passing silently, resulting in a non-activated chain stuck at level 0, as happened on Mondaynet today.

I tried:

* private chain on minikube: I see the `until` loop run a few times, and then the chain gets activated
* delete the activation job and run `helm upgrade`: job runs again, but is satisfied that activation already happened and exits silently