### PR TITLE
when snapshots can't be found for version, just pick the most recent

### DIFF
--- a/mkchain/tqchain/mkchain.py
+++ b/mkchain/tqchain/mkchain.py
@@ -250,7 +250,9 @@ def main():
             for key_type in keys:
                 accounts[key_type][account] = {
                     "key": keys[key_type],
-                    "is_bootstrap_baker_account": False if account == "authorized-key-0" else True,
+                    "is_bootstrap_baker_account": False
+                    if account == "authorized-key-0"
+                    else True,
                     "bootstrap_balance": "4000000000000",
                 }
 

--- a/utils/config-generator.py
+++ b/utils/config-generator.py
@@ -762,11 +762,14 @@ and octez version {octez_version}.
         and s.get("chain_name") == network_name
     ]
     if octez_version:
-        matching_snapshots = [
+        version_matching_snapshots = [
             s
             for s in matching_snapshots
             if int(octez_version) == s.get("tezos_version").get("version").get("major")
         ]
+        if len(version_matching_snapshots):
+            # If we can't find snapshots of the right octez version, we just pick the most recent available.
+            matching_snapshots = version_matching_snapshots
     matching_snapshots = sorted(matching_snapshots, key=lambda s: s.get("block_height"))
 
     return matching_snapshots[-1] if len(matching_snapshots) else None


### PR DESCRIPTION
Right now there are no v18 snapshots on xtz-shots, so it's not possible to kickstart a node. This PR will pick the v17 snapshot instead.